### PR TITLE
Add Owner and Anchors API for scope context management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **Owner and Anchors API**: Associate scopes with context objects
+  - `scope.Owner.*` API for managing a single distinguished owner
+  - `scope.Anchors.*` API for managing typed and named anchors
+  - Owner safety: `Set()` throws if owner already set, `Replace()` for explicit replacement
+  - Weak reference storage prevents memory leaks
+  - Fluent chaining with `.Scope` property to return to scope
+  - Direct composition via `Owner.Compose()` and `Anchors.Compose<T>()`
+  - Methods: `Set`, `Replace`, `Get`, `GetOrThrow`, `TryGet`, `Compose`, `GetComposition`
+  - Comprehensive documentation in ADR, README, API reference, and quick reference guide
+
 ## [1.0.0] - 2025-10-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ using var scope = new CapabilityScope();
 var document = new Document("README.md");
 
 // Compose capabilities
-var composition = scope.For(document)
+var composition = scope.Compose(document)
     .Add(new EditCapability())
     .Add(new PrintCapability())
     .Add(new ShareCapability())
@@ -60,7 +60,7 @@ Enforce a single "primary" capability per subject:
 ```csharp
 public record UserPrimaryCapability(string UserId, string Name) : IPrimaryCapability;
 
-var composition = scope.For(user)
+var composition = scope.Compose(user)
     .Add(new UserPrimaryCapability("user123", "John Doe"))
     .Add(new AdminCapability("Level2"))
     .Build();
@@ -75,7 +75,7 @@ Console.WriteLine($"User: {primary.Name}");
 Register a single capability under multiple contract types:
 
 ```csharp
-var composition = scope.For(myObject)
+var composition = scope.Compose(myObject)
     .AddAs<(IValidator, IFormatter)>(new DataProcessor())
     .Build();
 
@@ -84,10 +84,52 @@ var validator = composition.GetFirstOrDefault<IValidator>();
 var formatter = composition.GetFirstOrDefault<IFormatter>();
 ```
 
+### Owner and Anchors
+
+Associate scopes with well-known subjects for enhanced composability:
+
+```csharp
+// Setup scope with owner and anchors
+var pipeline = new PipelineHost("Main");
+var envContext = new EnvironmentContext { Name = "Production" };
+
+using var scope = new CapabilityScope();
+scope.Owner.Set(pipeline).Scope
+     .Anchors.Set<EnvironmentContext>(envContext).Scope
+     .Anchors.Set("tenant", tenantContext);
+
+// Later, compose capabilities using owner/anchors
+scope.Owner.Compose<PipelineHost>()
+           .Add(new DiagnosticsCapability())
+           .Build();
+
+scope.Anchors.Compose<EnvironmentContext>()
+             .Add(new EnvironmentCapability())
+             .Build();
+
+// Retrieve owner or anchors (throwing)
+var owner = scope.Owner.Get<PipelineHost>();
+var env = scope.Anchors.Get<EnvironmentContext>();
+
+// Safe retrieval for long-running scopes
+if (scope.Owner.TryGet<PipelineHost>(out var pipelineOwner))
+{
+    // Owner is alive, use it
+}
+
+if (scope.Anchors.TryGet<EnvironmentContext>(out var envAnchor))
+{
+    // Anchor is alive, use it
+}
+```
+
+**Learn more:** [Owner and Anchor Quick Reference](docs/owner-and-anchor-quick-reference.md)
+
 ## 📚 Documentation
 
 - **[Examples](docs/examples.md)** - Detailed examples and use cases
 - **[API Reference](docs/api-reference.md)** - Complete API documentation
+- **[Owner and Anchors](docs/owner-and-anchor-quick-reference.md)** - Scope association patterns
 
 ## 🎯 Key Concepts
 
@@ -95,6 +137,7 @@ var formatter = composition.GetFirstOrDefault<IFormatter>();
 - **Composer** - Fluent builder for creating compositions
 - **Composition** - Immutable collection of capabilities attached to a subject
 - **Primary Capability** - Single "main" capability per subject (via `IPrimaryCapability`)
+- **Owner & Anchors** - Associate scopes with well-known subjects for enhanced composability
 - **Registry** - Optional centralized management of compositions
 
 ---

--- a/adr/2025-10-25-scope-owner-and-anchors.md
+++ b/adr/2025-10-25-scope-owner-and-anchors.md
@@ -1,0 +1,141 @@
+# ADR: Introduce Owner and Anchor Support in `CapabilityScope`
+
+**Status:** Accepted
+**Date:** 2025-10-25
+**Context:** Applies to `Cocoar.Capabilities` (framework-level enhancement)
+**Decision Type:** Backward-compatible API extension
+
+---
+
+## 🧠 Context
+
+A `CapabilityScope` represents the lifecycle boundary for compositions. In many real-world systems, scopes are not conceptually isolated — they frequently originate from or are strongly associated with a *root subject*, such as:
+
+| Scenario                       | Root Subject                               |
+| ------------------------------ | ------------------------------------------ |
+| A configuration system         | Configuration manager/context              |
+| A plugin framework             | Hosting module                             |
+| A workflow engine              | Workflow definition or execution container |
+| A multi-tenant platform        | Tenant context                             |
+| A pipeline or builder instance | Pipeline host object                       |
+
+In such environments, code may later receive only the `CapabilityScope`, yet still need to enrich or inspect capabilities belonging to a specific, central subject tied to that scope (e.g., the manager, tenant, or engine).
+
+Today, there is no first-class way to associate or retrieve such “anchor subjects” from the scope. As a result, extension code must pass additional references around manually, or incorrectly treat the scope itself as a subject — which is semantically misleading.
+
+---
+
+## ✅ Decision
+
+We introduce a structured way to associate a scope with well-known subjects via **anchors**, along with a single optional **Owner** for clarity in scenarios where one subject is considered canonical.
+
+### The `CapabilityScope` will now support:
+
+| Concept           | Cardinality          | Purpose                                                                                             |
+| ----------------- | -------------------- | --------------------------------------------------------------------------------------------------- |
+| **Owner**         | 0 or 1               | A distinguished, primary subject that conceptually owns or leads this scope.                        |
+| **Typed Anchors** | ≤ 1 per `Type`       | Allows retrieval of a known subject by known type.                                                  |
+| **Named Anchors** | ≤ 1 per `string` key | Enables flexible contextual attachments (e.g., `"tenant:acme"`, `"environment"`, `"pipeline:foo"`). |
+
+### API characteristics
+
+✅ Anchors are stored as `WeakReference<object>` to prevent memory leaks.
+✅ **Owner safety**: `Owner.Set()` throws if owner already set; use `Owner.Replace()` for explicit replacement.
+✅ **Fluent chaining**: API returns self for fluent chaining; use `.Scope` to return to scope
+✅ Retrieval is explicit via `Owner.TryGet`, `Anchors.Get<T>()`, and `Anchors.TryGet()`.
+✅ Ergonomic sugar will exist for composing directly from owner/anchors:
+
+```csharp
+scope.Owner.Compose()
+scope.Owner.Compose<T>()
+scope.Anchors.Compose<T>()
+scope.Anchors.Compose("key")
+```
+
+✅ Anchors are optional; existing usage continues to work without modification.
+✅ `Owner` is a convenience anchor with semantic weight — but it is not mandatory.
+✅ **Grouped API**: All owner operations under `scope.Owner.*`, all anchor operations under `scope.Anchors.*`
+
+---
+
+## ✨ Example Usage
+
+```csharp
+// During scope initialization (e.g., in a host object)
+scope.Owner.Set(this).Scope  // Throws if called twice (use Replace for replacement)
+     .Anchors.Set<PipelineHost>(this).Scope
+     .Anchors.Set("environment", envContext);
+
+// Replacement scenario (explicit overwrite)
+scope.Owner.Replace(newHost);  // Explicit replacement allowed
+
+// Later – only scope is known:
+var host = scope.Owner.Get<PipelineHost>();
+scope.Compose(host).Add(new PipelineDiagnosticsCapability()).Build();
+
+// Via owner/anchor composition:
+scope.Owner.Compose().Add(new PipelineDiagnosticsCapability()).Build();
+
+// Via typed or named anchors:
+var env = scope.Anchors.Get<EnvironmentContext>();
+scope.Anchors.Compose<EnvironmentContext>().Add(new EnvironmentCapability()).Build();
+```
+
+---
+
+## 📍 Rationale
+
+This design:
+
+| Benefit                                                                                 | Explanation |
+| --------------------------------------------------------------------------------------- | ----------- |
+| ✅ Enables composition against meaningful subjects even when only the scope is available |             |
+| ✅ General-purpose (not tied to any specific domain or consumer)                         |             |
+| ✅ Future-proof (supports multi-tenant, multi-context, module-based architectures)       |             |
+| ✅ Improves clarity vs. attaching capabilities to the scope itself                       |             |
+| ✅ Weak references avoid retention issues                                                |             |
+| ✅ Backward compatible                                                                   |             |
+
+---
+
+## 📉 Alternatives Considered (and Rejected)
+
+| Option                                       | Rejected Because                                                               |
+| -------------------------------------------- | ------------------------------------------------------------------------------ |
+| Only a single Owner (no anchors)             | Too restrictive for scenarios with multiple contextual subjects                |
+| Only anchors (no Owner)                      | Loses clarity in cases where one subject is clearly primary                    |
+| Attaching capabilities directly to the scope | Blurs semantics — scope is a container, not a subject                          |
+| Ambient context (`AsyncLocal`, static)       | Implicit, harder to reason about, unsuitable for parallel scopes               |
+| Parent/child scopes                          | More complex than needed for this use case; may still be added later if needed |
+
+---
+
+## 📦 Consequences
+
+✅ Extension scenarios are now easier and more expressive
+✅ Small cognitive overhead: users must understand the distinction between scope, owner, and anchor subjects
+✅ Responsibility is on the scope creator to correctly assign anchors
+✅ Attempts to resolve missing or GC’d anchors result in `false` (for `Try...`) or exceptions (for `...OrThrow`)
+
+---
+
+## 📅 Next Steps
+
+| Task                                                               | Status |
+| ------------------------------------------------------------------ | ------ |
+| Implement Owner and anchor APIs with weak references               | ✅      |
+| Add `Owner.Set()` safety check (throw on duplicate)                | ✅      |
+| Add `Owner.Replace()` for explicit owner replacement               | ✅      |
+| Group API into `scope.Owner.*` and `scope.Anchors.*`              | ✅      |
+| Add `Owner.Compose()` / `Anchors.Compose()` composer helpers       | ✅      |
+| Add `GetOrThrow` aliases for explicit naming preference            | ✅      |
+| Add unit tests for anchor retrieval, GC cleanup, and failure cases | ✅      |
+| Add tests for Owner.Set/Replace safety behavior                    | ✅      |
+| Update documentation (README, ADR, quick reference)                | ✅      |
+
+---
+
+## ✅ Outcome
+
+`CapabilityScope` becomes contextual, extensible, and aware of its originating subject(s) without compromising immutability, safety, or generality.
+

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,6 +6,8 @@ Complete API reference for the Cocoar.Capabilities library.
 
 - [CapabilityScope](#capabilityscope)
 - [CapabilityScopeOptions](#capabilityscopeoptions)
+- [ScopeOwnerApi](#scopeownerapi)
+- [ScopeAnchorsApi](#scopeanchorsapi)
 - [Composer](#composer)
 - [IComposition](#icomposition)
 - [IPrimaryCapability](#iprimarycapability)
@@ -38,12 +40,14 @@ Entry point for all capability operations. Manages the lifecycle of composers an
 |----------|------|-------------|
 | `Composers` | `ComposerRegistryApi` | Provides access to the composer registry |
 | `Compositions` | `CompositionRegistryApi` | Provides access to the composition registry |
+| `Owner` | `ScopeOwnerApi` | Provides access to owner management operations |
+| `Anchors` | `ScopeAnchorsApi` | Provides access to anchor management operations |
 
 ### Example
 
 ```csharp
 using var scope = new CapabilityScope();
-var composer = scope.For(myObject);
+var composer = scope.Compose(myObject);
 var composition = composer.Add(new MyCapability()).Build();
 ```
 
@@ -75,6 +79,144 @@ var options = new CapabilityScopeOptions
 };
 ```
 
+---
+
+## ScopeOwnerApi
+
+Provides scope ownership management operations. Owners are single-valued context objects associated with a scope (e.g., user, request, pipeline). Each scope can have at most one owner.
+
+Access via `scope.Owner.*`
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Scope` | `CapabilityScope` | Returns the associated scope (for fluent chaining back to scope) |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `Set(object owner)` | `ScopeOwnerApi` | Sets the owner for the scope (throws if already set) |
+| `Replace(object owner)` | `ScopeOwnerApi` | Replaces the existing owner with a new one (throws if not set) |
+| `Get()` | `object?` | Gets the owner, or null if not set |
+| `GetOrThrow()` | `object` | Gets the owner, throws if not set (alias: `Require()`) |
+| `TryGet(out object owner)` | `bool` | Tries to get the owner, returns true if successful |
+| `Compose(Action<Composer> composerSetup)` | `IComposition` | Creates a composition for the owner (throws if not set) |
+| `GetComposition()` | `IComposition?` | Gets the existing composition for the owner, or null |
+
+### Exceptions
+
+| Method | Exception | Condition |
+|--------|-----------|-----------|
+| All methods | `ObjectDisposedException` | If scope is disposed |
+| `Set` | `InvalidOperationException` | If owner is already set |
+| `Replace` | `InvalidOperationException` | If owner is not set |
+| `GetOrThrow` | `InvalidOperationException` | If owner is not set |
+| `Compose` | `InvalidOperationException` | If owner is not set |
+
+### Example
+
+```csharp
+using var scope = new CapabilityScope();
+
+// Set owner once
+scope.Owner.Set(currentUser);
+
+// Get owner (various patterns)
+var owner = scope.Owner.Get();
+var requiredOwner = scope.Owner.GetOrThrow();
+if (scope.Owner.TryGet(out var o)) { /* use o */ }
+
+// Replace owner (runtime replacement scenario)
+scope.Owner.Replace(newUser);
+
+// Compose capabilities for owner
+var composition = scope.Owner.Compose(c => c
+    .Add(new UserPermissions())
+    .Add(new AuditLog()));
+
+// Fluent chaining back to scope
+scope.Owner.Set(currentUser).Scope.Anchors.Set<ILogger>(logger);
+```
+
+---
+
+## ScopeAnchorsApi
+
+Provides scope anchor management operations. Anchors are keyed context objects associated with a scope (e.g., logger, configuration, pipeline). Use typed anchors for compile-time safety or named anchors for string keys.
+
+Access via `scope.Anchors.*`
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Scope` | `CapabilityScope` | Returns the associated scope (for fluent chaining back to scope) |
+
+### Methods - Typed Anchors
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `Set<T>(T anchor)` | `ScopeAnchorsApi` | Sets a typed anchor (throws if already set) |
+| `Get<T>()` | `T?` | Gets a typed anchor, or null/default if not set |
+| `GetOrThrow<T>()` | `T` | Gets a typed anchor, throws if not set (alias: `Require<T>()`) |
+| `TryGet<T>(out T anchor)` | `bool` | Tries to get a typed anchor, returns true if successful |
+| `Compose<T>(Action<Composer> composerSetup)` | `IComposition` | Creates a composition for a typed anchor (throws if not set) |
+| `GetComposition<T>()` | `IComposition?` | Gets the existing composition for a typed anchor, or null |
+
+### Methods - Named Anchors
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `Set(string name, object anchor)` | `ScopeAnchorsApi` | Sets a named anchor (throws if already set) |
+| `Get(string name)` | `object?` | Gets a named anchor, or null if not set |
+| `GetOrThrow(string name)` | `object` | Gets a named anchor, throws if not set (alias: `Require(string)`) |
+| `TryGet(string name, out object anchor)` | `bool` | Tries to get a named anchor, returns true if successful |
+| `Compose(string name, Action<Composer> composerSetup)` | `IComposition` | Creates a composition for a named anchor (throws if not set) |
+| `GetComposition(string name)` | `IComposition?` | Gets the existing composition for a named anchor, or null |
+
+### Exceptions
+
+| Method | Exception | Condition |
+|--------|-----------|-----------|
+| All methods | `ObjectDisposedException` | If scope is disposed |
+| `Set<T>` / `Set(name, ...)` | `InvalidOperationException` | If anchor is already set |
+| `GetOrThrow<T>` / `GetOrThrow(name)` | `InvalidOperationException` | If anchor is not set |
+| `Compose<T>` / `Compose(name, ...)` | `InvalidOperationException` | If anchor is not set |
+
+### Example
+
+```csharp
+using var scope = new CapabilityScope();
+
+// Typed anchors (compile-time safety)
+scope.Anchors.Set<ILogger>(logger);
+scope.Anchors.Set<IConfiguration>(config);
+
+var log = scope.Anchors.Get<ILogger>();
+var requiredConfig = scope.Anchors.GetOrThrow<IConfiguration>();
+
+// Named anchors (runtime flexibility)
+scope.Anchors.Set("current-pipeline", pipeline1);
+scope.Anchors.Set("previous-pipeline", pipeline0);
+
+if (scope.Anchors.TryGet("current-pipeline", out var p))
+{
+    // use p
+}
+
+// Compose capabilities for anchors
+var composition = scope.Anchors.Compose<ILogger>(c => c
+    .Add(new LogFormatter())
+    .Add(new LogFilter()));
+
+// Fluent chaining
+scope.Anchors
+    .Set<ILogger>(logger)
+    .Set<IConfiguration>(config)
+    .Scope.Owner.Set(currentUser);
+```
 
 ---
 
@@ -113,7 +255,7 @@ Fluent builder for creating capability compositions.
 ### Example
 
 ```csharp
-var composition = scope.For(subject)
+var composition = scope.Compose(subject)
     .Add(new Capability1(), order: 10)
     .Add(new Capability2(), order: 5)
     .AddAs<(IContract1, IContract2)>(new MultiContract())
@@ -228,7 +370,7 @@ public record UserPrimaryCapability(string UserId, string Name) : IPrimaryCapabi
 public record DocumentPrimaryCapability(string Id, string Title) : IPrimaryCapability;
 
 // Use in composition
-var composition = scope.For(user)
+var composition = scope.Compose(user)
     .Add(new UserPrimaryCapability("user123", "John Doe"))
     .Add(new AdminCapability()) // Non-primary, OK
     .Build();
@@ -334,7 +476,7 @@ public class DocumentBuilder
 
     public DocumentBuilder(CapabilityScope scope, object subject)
     {
-        _composer = scope.For(subject);
+        _composer = scope.Compose(subject);
     }
 
     public DocumentBuilder WithEditing() 
@@ -351,7 +493,7 @@ public class DocumentBuilder
 
 ```csharp
 // Add strategies as capabilities, execute in order
-var composition = scope.For(processor)
+var composition = scope.Compose(processor)
     .Add(new ValidationStrategy(), order: 1)
     .Add(new TransformationStrategy(), order: 2)
     .Add(new PersistenceStrategy(), order: 3)
@@ -366,7 +508,7 @@ foreach (var strategy in composition.GetAll<IStrategy>())
 ### Chain of Responsibility
 
 ```csharp
-var composition = scope.For(request)
+var composition = scope.Compose(request)
     .Add(new AuthenticationHandler(), order: 1)
     .Add(new AuthorizationHandler(), order: 2)
     .Add(new ValidationHandler(), order: 3)
@@ -386,9 +528,10 @@ foreach (var handler in composition.GetAll<IRequestHandler>())
 
 ```csharp
 // Layer capabilities as decorators
-var composition = scope.For(service)
+var composition = scope.Compose(service)
     .Add(new LoggingDecorator(), order: 1)
     .Add(new CachingDecorator(), order: 2)
     .Add(new ValidationDecorator(), order: 3)
     .Build();
 ```
+

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -27,7 +27,7 @@ using var scope = new CapabilityScope();
 var document = new Document("README.md");
 
 // Compose capabilities
-var composition = scope.For(document)
+var composition = scope.Compose(document)
     .Add(new EditCapability())
     .Add(new PrintCapability())
     .Add(new ShareCapability())
@@ -59,7 +59,7 @@ if (printCap != null)
 When you know there's only one capability of a type, use `GetFirstOrDefault` or `TryGetFirst`:
 
 ```csharp
-var composition = scope.For(application)
+var composition = scope.Compose(application)
     .Add(new ConfigurationCapability("appsettings.json"))
     .Add(new LoggingCapability("app.log"))
     .Build();
@@ -108,7 +108,7 @@ if (composition.TryGetLast<ThemeCapability>(out var theme))
 
 ```csharp
 // Add multiple validation capabilities
-var composition = scope.For(formData)
+var composition = scope.Compose(formData)
     .Add(new ValidationCapability("Email", EmailValidator))
     .Add(new ValidationCapability("Phone", PhoneValidator))
     .Add(new ValidationCapability("ZipCode", ZipValidator))
@@ -130,7 +130,7 @@ public record AuditCapability(DateTime LastAudit);
 
 var user = new User("user123");
 
-var composition = scope.For(user)
+var composition = scope.Compose(user)
     .Add(new UserPrimaryCapability("user123", "John Doe"))
     .Add(new AdminCapability("Level2"))
     .Add(new AuditCapability(DateTime.Now))
@@ -155,7 +155,7 @@ Console.WriteLine($"Name: {typedPrimary.Name}");
 
 ```csharp
 // Only one primary capability is allowed
-var composition = scope.For(subject)
+var composition = scope.Compose(subject)
     .Add(new PrimaryCapabilityA("A"));
 
 // This will throw InvalidOperationException
@@ -172,7 +172,7 @@ catch (InvalidOperationException ex)
 ### Replacing Primary Capability via Recomposition
 
 ```csharp
-var initial = scope.For(user)
+var initial = scope.Compose(user)
     .Add(new GuestPrimaryCapability("guest123"))
     .Build();
 
@@ -206,7 +206,7 @@ public class DataProcessor : IValidator, IFormatter
 
 var processor = new DataProcessor();
 
-var composition = scope.For(myObject)
+var composition = scope.Compose(myObject)
     .AddAs<(IValidator, IFormatter)>(processor)
     .Build();
 
@@ -231,7 +231,7 @@ public class DataStore : IReadable, IWritable, ISearchable
 
 var store = new DataStore();
 
-var composition = scope.For(database)
+var composition = scope.Compose(database)
     .AddAs<(IReadable, IWritable, ISearchable)>(store)
     .Build();
 
@@ -247,7 +247,7 @@ var searchers = composition.GetAll<ISearchable>();
 
 ```csharp
 // Lower numbers = higher priority (returned first)
-var composition = scope.For(subject)
+var composition = scope.Compose(subject)
     .Add(new LoggingCapability(), order: 10)
     .Add(new ValidationCapability(), order: 5)
     .Add(new ProcessingCapability(), order: 20)
@@ -264,7 +264,7 @@ var all = composition.GetAll<ICapability>();
 ```csharp
 public record TaskCapability(string Name, int Priority);
 
-var composition = scope.For(taskList)
+var composition = scope.Compose(taskList)
     .Add(new TaskCapability("High Priority", 1), cap => cap.Priority)
     .Add(new TaskCapability("Normal Priority", 5), cap => cap.Priority)
     .Add(new TaskCapability("Low Priority", 10), cap => cap.Priority)
@@ -283,7 +283,7 @@ public record OrderedCapability
     public int ExecutionOrder { get; init; }
 }
 
-var composition = scope.For(pipeline)
+var composition = scope.Compose(pipeline)
     .Add(new OrderedCapability { Name = "Step1", ExecutionOrder = 10 }, 
          cap => cap.ExecutionOrder)
     .Add(new OrderedCapability { Name = "Step2", ExecutionOrder = 5 }, 
@@ -298,7 +298,7 @@ var composition = scope.For(pipeline)
 ### Basic Recomposition
 
 ```csharp
-var initialComposition = scope.For(document)
+var initialComposition = scope.Compose(document)
     .Add(new ReadCapability())
     .Build();
 
@@ -316,7 +316,7 @@ Console.WriteLine(updatedComposition.TotalCapabilityCount); // 3
 ### Conditional Recomposition
 
 ```csharp
-var composition = scope.For(user).Add(new BasicUserCapability()).Build();
+var composition = scope.Compose(user).Add(new BasicUserCapability()).Build();
 
 // Add admin capabilities if user is admin
 if (userIsAdmin)
@@ -339,7 +339,7 @@ if (hasPremiumSubscription)
 ### Recomposition with Ordering Changes
 
 ```csharp
-var initial = scope.For(pipeline)
+var initial = scope.Compose(pipeline)
     .Add(new StepA(), 1)
     .Add(new StepB(), 2)
     .Build();
@@ -365,7 +365,7 @@ var options = new CapabilityScopeOptions
 using var scope = new CapabilityScope(options);
 
 // Build with registry
-var composition = scope.For(document)
+var composition = scope.Compose(document)
     .Add(new EditCapability())
     .Build(); // Automatically registered
 
@@ -408,7 +408,7 @@ var options = new CapabilityScopeOptions { UseComposerRegistry = true };
 using var scope = new CapabilityScope(options);
 
 // Start composing
-var composer = scope.For(document); // Registered automatically
+var composer = scope.Compose(document); // Registered automatically
 
 // Check if a composer is active
 if (scope.Composers.Has(document))
@@ -438,7 +438,7 @@ var options = new CapabilityScopeOptions
 using var scope = new CapabilityScope(options);
 
 // Override: use registry for this specific operation
-var composition = scope.For(subject, useRegistry: true)
+var composition = scope.Compose(subject, useRegistry: true)
     .Add(capability)
     .Build(useRegistry: true);
 
@@ -452,7 +452,7 @@ Console.WriteLine(found != null); // True
 ### Basic Try-Add
 
 ```csharp
-var composition = scope.For(document)
+var composition = scope.Compose(document)
     .Add(new LoggingCapability())
     .TryAdd(new LoggingCapability()) // Won't add duplicate
     .TryAdd(new MetricsCapability())  // Will add (doesn't exist yet)
@@ -465,7 +465,7 @@ Console.WriteLine(composition.GetAll<MetricsCapability>().Count); // 1
 ### Conditional Capability Addition
 
 ```csharp
-var composer = scope.For(user);
+var composer = scope.Compose(user);
 
 // Add base capabilities
 composer.Add(new UserProfileCapability());
@@ -485,7 +485,7 @@ var composition = composer.Build();
 ### Try-Add with Ordering
 
 ```csharp
-var composition = scope.For(pipeline)
+var composition = scope.Compose(pipeline)
     .Add(new StepA(), 10)
     .TryAdd(new StepA(), 5) // Won't add, already exists
     .TryAdd(new StepB(), 20) // Will add
@@ -517,7 +517,7 @@ public record ExporterPlugin(string Name, string Format) : IPlugin
 using var scope = new CapabilityScope();
 var app = new Application();
 
-var composition = scope.For(app)
+var composition = scope.Compose(app)
     .Add(new EditorPlugin("TextEditor"))
     .Add(new EditorPlugin("CodeEditor"))
     .Add(new EditorPlugin("MarkdownEditor"))
@@ -545,7 +545,7 @@ public record Permission(string Resource, string Action);
 
 var user = new User("john@example.com");
 
-var composition = scope.For(user)
+var composition = scope.Compose(user)
     .Add(new UserRole("Admin"))
     .Add(new Permission("Users", "Read"))
     .Add(new Permission("Users", "Write"))
@@ -608,7 +608,7 @@ public record MetricsCollector() : IEventHandler
 // Setup event processing
 var order = new Order("ORD-001");
 
-var composition = scope.For(order)
+var composition = scope.Compose(order)
     .Add(new AuditLogger(), order: 1)
     .Add(new NotificationSender(), order: 2)
     .Add(new MetricsCollector(), order: 3)
@@ -641,7 +641,7 @@ public record BetaFeature(string FeatureName, bool IsEnabled) : IFeature;
 
 var app = new Application();
 
-var composer = scope.For(app);
+var composer = scope.Compose(app);
 
 // Load features from configuration
 var featureConfig = LoadFeatureConfiguration();
@@ -709,7 +709,7 @@ public record PersistenceMiddleware() : IDocumentMiddleware
 // Setup processing pipeline
 var document = new Document("report.pdf");
 
-var composition = scope.For(document)
+var composition = scope.Compose(document)
     .Add(new ValidationMiddleware(), order: 1)
     .Add(new TransformationMiddleware(), order: 2)
     .Add(new PersistenceMiddleware(), order: 3)
@@ -761,7 +761,7 @@ public record PushNotification() : INotificationService
 // User preferences determine notification methods
 var user = new User("user@example.com");
 
-var composer = scope.For(user);
+var composer = scope.Compose(user);
 
 if (preferences.EmailEnabled)
     composer.Add(new EmailNotification());
@@ -783,3 +783,4 @@ async Task NotifyUser(IComposition comp, string message)
 
 await NotifyUser(composition, "Your order has shipped!");
 ```
+

--- a/docs/owner-and-anchor-quick-reference.md
+++ b/docs/owner-and-anchor-quick-reference.md
@@ -1,0 +1,217 @@
+# Owner and Anchor Quick Reference
+
+## When to Use
+
+Use **Owner** when:
+- ✅ Your scope has one primary/canonical subject
+- ✅ You want semantic clarity about what "owns" the scope
+- ✅ Examples: Configuration manager, Pipeline host, Workflow engine
+
+Use **Typed Anchors** when:
+- ✅ You need to associate well-known types with the scope
+- ✅ You have multiple distinct contexts (environment, tenant, etc.)
+- ✅ You want compile-time type safety
+
+Use **Named Anchors** when:
+- ✅ You need flexible, runtime-defined keys
+- ✅ You have contextual data like "tenant:acme" or "environment"
+- ✅ You want string-based lookups
+
+## API Quick Reference
+
+### Setting (Fluent)
+```csharp
+// Set owner (throws if already set)
+scope.Owner.Set(myHost)
+     .Scope.Anchors.Set<EnvironmentContext>(envCtx)
+     .Scope.Anchors.Set("tenant", tenantCtx);
+
+// Replace owner (explicitly overwrite)
+scope.Owner.Replace(newHost);
+
+// Alternative: all in one chain
+scope.Owner.Set(myHost).Scope
+     .Anchors.Set<EnvironmentContext>(envCtx).Scope
+     .Anchors.Set("tenant", tenantCtx);
+```
+
+### Retrieving (Throwing)
+```csharp
+var owner = scope.Owner.Get<MyHost>();
+var env = scope.Anchors.Get<EnvironmentContext>();
+var tenant = scope.Anchors.Get("tenant");
+
+// Alias methods (same behavior)
+var owner = scope.Owner.GetOrThrow<MyHost>();
+var env = scope.Anchors.GetOrThrow<EnvironmentContext>();
+var tenant = scope.Anchors.GetOrThrow("tenant");
+```
+
+### Retrieving (Safe)
+```csharp
+if (scope.Owner.TryGet<MyHost>(out var owner)) { ... }
+if (scope.Anchors.TryGet<EnvironmentContext>(out var env)) { ... }
+if (scope.Anchors.TryGet("tenant", out var tenant)) { ... }
+```
+
+### Composing
+
+There are three tiers of composition helpers:
+
+**Tier 1: Direct subject composition**
+```csharp
+var subject = new MySubject();
+scope.Compose(subject)
+     .Add(new MyCapability())
+     .Build();
+```
+
+**Tier 2: Owner composition**
+```csharp
+// Type-inferred from set owner
+scope.Owner.Compose()
+           .Add(new MyCapability())
+           .Build();
+
+// Explicit type check
+scope.Owner.Compose<MyHost>()
+           .Add(new MyCapability())
+           .Build();
+```
+
+**Tier 3: Anchor composition**
+```csharp
+// For typed anchor
+scope.Anchors.Compose<EnvironmentContext>()
+             .Add(new EnvCapability())
+             .Build();
+
+// For named anchor
+scope.Anchors.Compose("tenant")
+             .Add(new TenantCapability())
+             .Build();
+```
+
+## Common Patterns
+
+### Pattern 1: Single Owner
+```csharp
+var manager = new ConfigurationManager();
+using var scope = new CapabilityScope();
+scope.Owner.Set(manager);
+
+// Later, in extension code:
+void EnrichConfig(CapabilityScope scope)
+{
+    var mgr = scope.Owner.Get<ConfigurationManager>();
+    scope.Owner.Compose().Add(new ConfigCap()).Build();
+}
+```
+
+### Pattern 2: Owner + Typed Anchors
+```csharp
+using var scope = new CapabilityScope();
+scope.Owner.Set(pipeline).Scope
+     .Anchors.Set(environment).Scope
+     .Anchors.Set(tenant);
+
+scope.Owner.Compose<Pipeline>().Add(...).Build();
+scope.Anchors.Compose<Environment>().Add(...).Build();
+scope.Anchors.Compose<Tenant>().Add(...).Build();
+```
+
+### Pattern 3: Named Anchors for Flexibility
+```csharp
+scope.Anchors.Set("primary-db", dbContext).Scope
+     .Anchors.Set("cache", cacheContext).Scope
+     .Anchors.Set("tenant:acme", tenantA).Scope
+     .Anchors.Set("tenant:globex", tenantB);
+
+scope.Anchors.Compose("primary-db").Add(...).Build();
+scope.Anchors.Compose("tenant:acme").Add(...).Build();
+```
+
+### Pattern 4: Owner Replacement
+```csharp
+// Initial setup
+var oldPipeline = new Pipeline("v1");
+using var scope = new CapabilityScope();
+scope.Owner.Set(oldPipeline); // Safe initialization
+
+// Later, replace with new pipeline
+var newPipeline = new Pipeline("v2");
+scope.Owner.Replace(newPipeline); // Explicit replacement
+
+// Set would throw here:
+// scope.Owner.Set(anotherPipeline); // ❌ InvalidOperationException
+```
+
+## Error Handling
+
+### Exception Matrix
+
+| Method | Condition | Exception |
+|--------|-----------|-----------|
+| `Owner.Set(owner)` | Owner already set and alive | `InvalidOperationException` |
+| `Owner.Set(owner)` | Null owner | `ArgumentNullException` |
+| `Owner.Set(owner)` | Scope disposed | `ObjectDisposedException` |
+| `Owner.Replace(owner)` | Null owner | `ArgumentNullException` |
+| `Owner.Replace(owner)` | Scope disposed | `ObjectDisposedException` |
+| `Owner.Get<T>()` | Owner not set | `InvalidOperationException` |
+| `Owner.Get<T>()` | Owner garbage collected | `InvalidOperationException` |
+| `Owner.Get<T>()` | Type mismatch | `InvalidCastException` |
+| `Owner.Get<T>()` | Scope disposed | `ObjectDisposedException` |
+| `Owner.TryGet<T>(out owner)` | Scope disposed | `ObjectDisposedException` |
+| `Anchors.Set<T>(anchor)` | Null anchor | `ArgumentNullException` |
+| `Anchors.Set<T>(anchor)` | Scope disposed | `ObjectDisposedException` |
+| `Anchors.Set(key, anchor)` | Null key or anchor | `ArgumentNullException` |
+| `Anchors.Set(key, anchor)` | Scope disposed | `ObjectDisposedException` |
+| `Anchors.Get<T>()` | Anchor not set | `InvalidOperationException` |
+| `Anchors.Get<T>()` | Anchor garbage collected | `InvalidOperationException` |
+| `Anchors.Get<T>()` | Scope disposed | `ObjectDisposedException` |
+| `Anchors.Get(key)` | Anchor not set | `InvalidOperationException` |
+| `Anchors.Get(key)` | Anchor garbage collected | `InvalidOperationException` |
+| `Anchors.Get(key)` | Null key | `ArgumentNullException` |
+| `Anchors.Get(key)` | Scope disposed | `ObjectDisposedException` |
+| `Anchors.TryGet<T>(out anchor)` | Scope disposed | `ObjectDisposedException` |
+| `Anchors.TryGet(key, out anchor)` | Null key | `ArgumentNullException` |
+| `Anchors.TryGet(key, out anchor)` | Scope disposed | `ObjectDisposedException` |
+
+**Note:** `Try*` methods return `false` (instead of throwing) when owner/anchor is not set, garbage collected, or wrong type.
+**Note:** `GetOrThrow` methods are aliases for `Get` methods (same behavior).
+
+## Memory Management
+
+All owner and anchors are stored as **WeakReference<object>**:
+- ✅ Won't prevent garbage collection
+- ✅ Safe for long-lived scopes
+- ⚠️ Must keep subjects alive if needed
+- ⚠️ Check for collection in long-running scenarios
+
+**Named Anchors:** Keys use **Ordinal** string comparison (case-sensitive).
+
+## Best Practices
+
+1. **Set early**: Configure owner/anchors during scope initialization
+2. **Use Owner.Set for initialization**: First-time owner setting (throws if duplicate)
+3. **Use Owner.Replace for replacement**: Explicitly replace owner when needed
+4. **Use Try* variants**: When subject lifetime is uncertain
+5. **Type-safe when possible**: Prefer typed anchors over named
+6. **Named for runtime keys**: Use when keys aren't known at compile time
+7. **One owner max**: Semantic clarity - use anchors for additional subjects
+8. **Weak refs are weak**: Keep subjects alive in calling code if needed
+9. **Document keys**: If using named anchors, document the key strings
+10. **Fluent chaining**: Use `.Scope` to return from API to scope for chaining
+
+## Anti-Patterns
+
+❌ Don't use owner for multiple subjects (use anchors instead)  
+❌ Don't assume owner/anchors are always alive (check or use Try* variants)  
+❌ Don't set new owner/anchors after scope is widely used (set early)  
+❌ Don't use scope itself as a subject (use owner instead)  
+❌ Don't use Owner.Set to replace an owner (use Owner.Replace for explicit intent)  
+
+## See Also
+
+- ADR: [Scope Owner and Anchors](../adr/2025-10-25-scope-owner-and-anchors.md)
+- Tests: `src/Cocoar.Capabilities.Tests/OwnerAndAnchor*.cs`

--- a/src/Cocoar.Capabilities.Benchmarks/CanonicalizationBenchmarks.cs
+++ b/src/Cocoar.Capabilities.Benchmarks/CanonicalizationBenchmarks.cs
@@ -33,7 +33,7 @@ public class CanonicalizationBenchmarks : IDisposable
         for (int i = 0; i < SubjectCount; i++)
         {
             var subject = _stringSubjects[i];
-            var composer = _stringScope.For(subject);
+            var composer = _stringScope.Compose(subject);
             for (int c = 0; c < CapabilitiesPerSubject; c++) composer.Add(new StringCapability($"C{c}"));
             composer.Build(useRegistry: true);
         }
@@ -45,7 +45,7 @@ public class CanonicalizationBenchmarks : IDisposable
         for (int i = 0; i < SubjectCount; i++)
         {
             var subject = _valueSubjects[i];
-            var composer = _valueScope.For(subject);
+            var composer = _valueScope.Compose(subject);
             for (int c = 0; c < CapabilitiesPerSubject; c++) composer.Add(new ValueCapability($"C{c}"));
             composer.Build(useRegistry: true);
         }

--- a/src/Cocoar.Capabilities.Benchmarks/CapabilityBenchmarks.cs
+++ b/src/Cocoar.Capabilities.Benchmarks/CapabilityBenchmarks.cs
@@ -43,7 +43,7 @@ public class CapabilityBenchmarks
         {
             // Single subject scenario
             var subject = new TestSubject(0, "Subject_0");
-            var composer = BenchmarkScopes.Shared.For(subject);
+            var composer = BenchmarkScopes.Shared.Compose(subject);
             
             for (int c = 0; c < capabilitiesPerSubject; c++)
             {
@@ -58,7 +58,7 @@ public class CapabilityBenchmarks
             // Multiple subjects - build separately and combine manually for testing
             // Note: This is a simplified approach for benchmarking purposes
             var firstSubject = new TestSubject(0, "Subject_0");
-            var composer = BenchmarkScopes.Shared.For(firstSubject);
+            var composer = BenchmarkScopes.Shared.Compose(firstSubject);
             
             // Add capabilities for just the first subject to get basic composition
             for (int c = 0; c < capabilitiesPerSubject; c++)
@@ -73,7 +73,7 @@ public class CapabilityBenchmarks
     
     private static IComposition CreateAndRegisterComposition(TestSubject subject, int capabilitiesCount)
     {
-        var composer = BenchmarkScopes.Shared.For(subject);
+        var composer = BenchmarkScopes.Shared.Compose(subject);
         
         for (int c = 0; c < capabilitiesCount; c++)
         {
@@ -142,7 +142,7 @@ public class CapabilityBenchmarks
     {
         // Use same pattern as Core version for fair comparison
         var subject = new TestSubject(0, "Subject_0");
-        var composer = BenchmarkScopes.Shared.For(subject);
+        var composer = BenchmarkScopes.Shared.Compose(subject);
         
         for (int c = 0; c < 50; c++)
         {
@@ -162,7 +162,7 @@ public class CapabilityBenchmarks
     {
         // Use SAME subject ID as Core version for fair comparison
         var subject = new TestSubject(0, "Subject_0");
-        var composer = BenchmarkScopes.Shared.For(subject);
+        var composer = BenchmarkScopes.Shared.Compose(subject);
         
         for (int c = 0; c < 500; c++)
         {

--- a/src/Cocoar.Capabilities.Benchmarks/CoreVsRegistryBenchmarks.cs
+++ b/src/Cocoar.Capabilities.Benchmarks/CoreVsRegistryBenchmarks.cs
@@ -144,7 +144,7 @@ public class CoreVsRegistryBenchmarks
     {
         var subject = new TestSubject(0, "CoreSubject");
         // Use lightweight scope (registries disabled)
-        var composer = BenchmarkScopes.SharedLightweight.For(subject);
+        var composer = BenchmarkScopes.SharedLightweight.Compose(subject);
         
         for (int c = 0; c < capabilitiesPerSubject; c++)
         {
@@ -157,7 +157,7 @@ public class CoreVsRegistryBenchmarks
 
     private static IComposition CreateRegistryComposition(TestSubject subject, int capabilitiesPerSubject)
     {
-        var composer = BenchmarkScopes.Shared.For(subject);
+        var composer = BenchmarkScopes.Shared.Compose(subject);
         
         for (int c = 0; c < capabilitiesPerSubject; c++)
         {

--- a/src/Cocoar.Capabilities.Benchmarks/OrderingBenchmarks.cs
+++ b/src/Cocoar.Capabilities.Benchmarks/OrderingBenchmarks.cs
@@ -67,7 +67,7 @@ public class OrderingBenchmarks : IDisposable
     [Benchmark(Description = "Build: Ordered (Already Sorted)")] 
     public IComposition Build_Ordered_AlreadySorted()
     {
-        var composer = _scope.For(new Subject(2, "Sorted"));
+        var composer = _scope.Compose(new Subject(2, "Sorted"));
         for (int i = 0; i < Count; i++)
         {
             composer.Add(new OrderedCap($"C{i}", i));
@@ -78,7 +78,7 @@ public class OrderingBenchmarks : IDisposable
     [Benchmark(Description = "Build: Ordered (Reverse -> Worst Case)")] 
     public IComposition Build_Ordered_Reverse()
     {
-        var composer = _scope.For(new Subject(3, "Reverse"));
+        var composer = _scope.Compose(new Subject(3, "Reverse"));
         for (int i = 0; i < Count; i++)
         {
             composer.Add(new OrderedCap($"C{i}", _reverseOrder[i]));
@@ -89,7 +89,7 @@ public class OrderingBenchmarks : IDisposable
     [Benchmark(Description = "Build: Ordered (Duplicate Priorities)")] 
     public IComposition Build_Ordered_Duplicates()
     {
-        var composer = _scope.For(new Subject(4, "Duplicates"));
+        var composer = _scope.Compose(new Subject(4, "Duplicates"));
         for (int i = 0; i < Count; i++)
         {
             composer.Add(new OrderedCap($"C{i}", _duplicateOrder[i]));
@@ -167,14 +167,14 @@ public class OrderingBenchmarks : IDisposable
 
     private IComposition BuildUnorderedInternal()
     {
-        var composer = _scope.For(new Subject(10, "Unordered"));
+        var composer = _scope.Compose(new Subject(10, "Unordered"));
         for (int i = 0; i < Count; i++) composer.Add(new PlainCap($"C{i}"));
         return composer.Build();
     }
 
     private IComposition BuildOrderedRandomInternal()
     {
-        var composer = _scope.For(new Subject(11, "OrderedRandom"));
+        var composer = _scope.Compose(new Subject(11, "OrderedRandom"));
         for (int i = 0; i < Count; i++) composer.Add(new OrderedCap($"C{i}", _randomOrder[i]));
         return composer.Build();
     }

--- a/src/Cocoar.Capabilities.Benchmarks/RecompositionBenchmarks.cs
+++ b/src/Cocoar.Capabilities.Benchmarks/RecompositionBenchmarks.cs
@@ -19,7 +19,7 @@ public class RecompositionBenchmarks : IDisposable
     {
         _scope = new CapabilityScope();
         _subject = new TestSubject(1, "RecomposeSubject");
-        var composer = _scope.For(_subject);
+        var composer = _scope.Compose(_subject);
         for (int i = 0; i < 50; i++) composer.Add(new Cap($"C{i}"));
         composer.WithPrimary(new Primary("P0"));
         _baseComposition = composer.Build(useRegistry: true);

--- a/src/Cocoar.Capabilities.Tests/BasicCompositionTests.cs
+++ b/src/Cocoar.Capabilities.Tests/BasicCompositionTests.cs
@@ -10,7 +10,7 @@ public class BasicCompositionTests
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("s1");
 
-        var composition = scope.For(subject, useRegistry: false)
+        var composition = scope.Compose(subject, useRegistry: false)
             .Add(new TestCapability("A"))
             .Build(useRegistry: false);
 
@@ -29,7 +29,7 @@ public class BasicCompositionTests
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("s2");
 
-        var composition = scope.For(subject, useRegistry: true)
+        var composition = scope.Compose(subject, useRegistry: true)
             .Add(new TestCapability("B"))
             .Build(useRegistry: true);
 
@@ -46,7 +46,7 @@ public class BasicCompositionTests
         var subject = new StringSubject("contracts");
         var impl = new MultiContractImplementation("multi", "desc", 42);
 
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .AddAs<(ITestContract, IAlternateContract)>(impl)
             .Build();
 
@@ -64,7 +64,7 @@ public class BasicCompositionTests
     {
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("prim");
-        var builder = scope.For(subject)
+        var builder = scope.Compose(subject)
             .Add(new PrimaryTestCapability("P1"));
 
         var ex = Assert.Throws<InvalidOperationException>(() => builder.Add(new AlternatePrimaryCapability("P2")));

--- a/src/Cocoar.Capabilities.Tests/BuildRegistryDecisionMatrixTests.cs
+++ b/src/Cocoar.Capabilities.Tests/BuildRegistryDecisionMatrixTests.cs
@@ -43,7 +43,7 @@ public class BuildRegistryDecisionMatrixTests
         bool effectiveComposition = compositionOverride ?? scopeCompositionDefault;
 
         // Create composer (registration may happen now)
-        var composer = scope.For(subject, composerOverride);
+        var composer = scope.Compose(subject, composerOverride);
         composer.Add(new TestCapability("T"));
 
         var preComposer = scope.Composers.GetOrDefault(subject);

--- a/src/Cocoar.Capabilities.Tests/BuildRegistryDecisionTests.cs
+++ b/src/Cocoar.Capabilities.Tests/BuildRegistryDecisionTests.cs
@@ -12,7 +12,7 @@ public class BuildRegistryDecisionTests
     {
         using var scope = CreateScope(false, false);
         var subject = new StringSubject("s1");
-        var comp = scope.For(subject).Add(new TestCapability("A")).Build();
+        var comp = scope.Compose(subject).Add(new TestCapability("A")).Build();
         Assert.Null(scope.Composers.GetOrDefault(subject));
         Assert.Null(scope.Compositions.GetOrDefault(subject));
         Assert.Same(subject, comp.Subject);
@@ -23,7 +23,7 @@ public class BuildRegistryDecisionTests
     {
         using var scope = CreateScope(false, false);
         var subject = new StringSubject("s2");
-        var comp = scope.For(subject, useRegistry: false) // composer override false (explicit)
+        var comp = scope.Compose(subject, useRegistry: false) // composer override false (explicit)
                         .Add(new TestCapability("B"))
                         .Build(useRegistry: true); // composition override true
         Assert.Null(scope.Composers.GetOrDefault(subject)); // composer not registered
@@ -38,7 +38,7 @@ public class BuildRegistryDecisionTests
     {
         using var scope = CreateScope(true, true); // defaults both true
         var subject = new StringSubject("s3");
-        var builder = scope.For(subject, useRegistry: true) // composer registered
+        var builder = scope.Compose(subject, useRegistry: true) // composer registered
                            .Add(new TestCapability("C"));
         var comp = builder.Build(useRegistry: false); // disable composition
         Assert.Null(scope.Compositions.GetOrDefault(subject)); // composition not registered
@@ -51,7 +51,7 @@ public class BuildRegistryDecisionTests
     {
         using var scope = CreateScope(true, true);
         var subject = new StringSubject("s4");
-        var comp = scope.For(subject) // default true -> composer registered
+        var comp = scope.Compose(subject) // default true -> composer registered
                         .Add(new TestCapability("D"))
                         .Build(); // default true -> transition
         Assert.Null(scope.Composers.GetOrDefault(subject)); // composer transitioned away
@@ -66,7 +66,7 @@ public class BuildRegistryDecisionTests
     {
         using var scope = CreateScope(false, true);
         var subject = new StringSubject("s5");
-        var comp = scope.For(subject, useRegistry: false)
+        var comp = scope.Compose(subject, useRegistry: false)
                         .Add(new TestCapability("E"))
                         .Build(); // composition default true
         Assert.Null(scope.Composers.GetOrDefault(subject));
@@ -81,7 +81,7 @@ public class BuildRegistryDecisionTests
     {
         using var scope = CreateScope(composerReg: true, compositionReg: false);
         var subject = new StringSubject("s6");
-        var composer = scope.For(subject); // composer registered
+        var composer = scope.Compose(subject); // composer registered
         composer.Add(new TestCapability("X"));
         Assert.NotNull(scope.Composers.GetOrDefault(subject)); // pre-build composer present
         var composition = composer.Build(); // composition registry disabled -> no registration
@@ -95,7 +95,7 @@ public class BuildRegistryDecisionTests
     {
         using var scope = CreateScope(true, true);
         var subject = new StringSubject("s7");
-        var composer = scope.For(subject); // composer registered
+        var composer = scope.Compose(subject); // composer registered
         composer.Add(new TestCapability("Y"));
         var composerPre = scope.Composers.GetOrDefault(subject);
         Assert.NotNull(composerPre);

--- a/src/Cocoar.Capabilities.Tests/CapabilityEntryTests.cs
+++ b/src/Cocoar.Capabilities.Tests/CapabilityEntryTests.cs
@@ -13,7 +13,7 @@ public class CapabilityEntryTests
     {
         using var scope = new CapabilityScope();
         var subject = new Subject(1);
-        var comp = scope.For(subject).Add(new Cap("A")).WithPrimary(new Primary("P"))
+        var comp = scope.Compose(subject).Add(new Cap("A")).WithPrimary(new Primary("P"))
             .Build(useRegistry: true);
 
         // Use object-based registry path (exercises CapabilityEntry.TryGetComposition(object&))
@@ -43,7 +43,7 @@ public class CapabilityEntryTests
     {
         var scope = new CapabilityScope();
         var subject = new Subject(5);
-        var composer = scope.For(subject).Add(new Cap("A"));
+        var composer = scope.Compose(subject).Add(new Cap("A"));
         var comp = composer.Build(useRegistry: true);
         // Recompose so registry entry transitions (ensures entry holds composition after composer removal/transition lifecycle)
         var recomposer = scope.Recompose(comp);

--- a/src/Cocoar.Capabilities.Tests/Cocoar.Capabilities.Tests.csproj
+++ b/src/Cocoar.Capabilities.Tests/Cocoar.Capabilities.Tests.csproj
@@ -8,6 +8,7 @@
     <!-- Relax analyzer rules for tests -->
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningLevel>3</WarningLevel>
+    <NoWarn>$(NoWarn);CA1001;CA1051</NoWarn>
   </PropertyGroup>
 
   <!-- ===== TEST FRAMEWORK ===== -->

--- a/src/Cocoar.Capabilities.Tests/ComposerPrimaryNegativeTests.cs
+++ b/src/Cocoar.Capabilities.Tests/ComposerPrimaryNegativeTests.cs
@@ -11,7 +11,7 @@ public class ComposerPrimaryNegativeTests
     public void Add_DuplicatePrimary_Throws()
     {
         using var scope = new CapabilityScope();
-        var composer = scope.For(new Subject(1));
+        var composer = scope.Compose(new Subject(1));
         composer.Add(new PrimaryA("P1"));
         Assert.Throws<InvalidOperationException>(() => composer.Add(new PrimaryB("P2")));
     }
@@ -20,7 +20,7 @@ public class ComposerPrimaryNegativeTests
     public void AddAs_PrimaryContract_Duplicate_Throws()
     {
         using var scope = new CapabilityScope();
-        var composer = scope.For(new Subject(2));
+        var composer = scope.Compose(new Subject(2));
         composer.AddAs<IPrimaryCapability>(new PrimaryA("P1"));
         Assert.Throws<InvalidOperationException>(() => composer.AddAs<IPrimaryCapability>(new PrimaryB("P2")));
     }
@@ -29,7 +29,7 @@ public class ComposerPrimaryNegativeTests
     public void AddTuple_WithPrimaryThenDuplicatePrimary_Throws()
     {
         using var scope = new CapabilityScope();
-        var composer = scope.For(new Subject(3));
+        var composer = scope.Compose(new Subject(3));
         composer.AddAs<(IPrimaryCapability, PrimaryA)>(new PrimaryA("P1"));
         Assert.Throws<InvalidOperationException>(() => composer.AddAs<(IPrimaryCapability, PrimaryB)>(new PrimaryB("P2")));
     }

--- a/src/Cocoar.Capabilities.Tests/ConfigTests/ConcreteConfigBuilder.cs
+++ b/src/Cocoar.Capabilities.Tests/ConfigTests/ConcreteConfigBuilder.cs
@@ -6,7 +6,7 @@ public sealed class ConcreteConfigBuilder<T> : ConfigBuilder where T : class
     public Guid Id { get; } = Guid.NewGuid();
     internal ConcreteConfigBuilder(CapabilityScope capabilityScope): base(capabilityScope)
     {
-       capabilityScope.For(this).WithPrimary(
+       capabilityScope.Compose(this).WithPrimary(
             new ConcreteTypePrimary<ConfigBuilder>(typeof(T)));
     }
     

--- a/src/Cocoar.Capabilities.Tests/ConfigTests/ConfigurationTests.cs
+++ b/src/Cocoar.Capabilities.Tests/ConfigTests/ConfigurationTests.cs
@@ -20,7 +20,7 @@ public class AppSettings : IAppSettings
 
 public class ConfigManager
 {
-    public readonly List<ConfigBuilder> _configurations;
+    public List<ConfigBuilder> _configurations { get; }
     private readonly CapabilityScope _capabilityScope = new();
 
     public ConfigManager(Func<ConfigureBuilder, ConfigBuilder[]> configure)

--- a/src/Cocoar.Capabilities.Tests/ConfigTests/ConfigureBuilder.cs
+++ b/src/Cocoar.Capabilities.Tests/ConfigTests/ConfigureBuilder.cs
@@ -8,7 +8,7 @@ public interface IConfigureBuilder
 
 public abstract class ConfigBuilder(CapabilityScope capabilityScope): IConfigureBuilder
 {
-    protected readonly CapabilityScope CapabilityScope = capabilityScope;
+    protected CapabilityScope CapabilityScope {get;} = capabilityScope;
     internal abstract ConfigBuilder Build();
 
     public static CapabilityScope GetCapabilityScopeFor(ConfigBuilder builder) => builder.CapabilityScope;

--- a/src/Cocoar.Capabilities.Tests/CustomStringMapperTests.cs
+++ b/src/Cocoar.Capabilities.Tests/CustomStringMapperTests.cs
@@ -22,7 +22,7 @@ public sealed class CustomStringMapperTests
             SubjectKeyMappers = new[] { new CaseInsensitiveStringMapper() }
         });
 
-        var composer = scope.For(" hello ")
+        var composer = scope.Compose(" hello ")
             .Add(new SimpleCapability())
             .Build();
 
@@ -42,7 +42,7 @@ public sealed class CustomStringMapperTests
             SubjectKeyMappers = new ISubjectKeyMapper[] { first, second }
         });
 
-        var composer = scope.For("a")
+        var composer = scope.Compose("a")
             .Add(new SimpleCapability())
             .Build();
 

--- a/src/Cocoar.Capabilities.Tests/DelegateCapabilityTests.cs
+++ b/src/Cocoar.Capabilities.Tests/DelegateCapabilityTests.cs
@@ -17,7 +17,7 @@ public class DelegateCapabilityTests
         Action<string> action3 = msg => messages.Add($"Action3: {msg}");
 
         // Act
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(action1)
             .Add(action2)
             .Add(action3)
@@ -50,7 +50,7 @@ public class DelegateCapabilityTests
         Func<int, int> addTen = x => x + 10;
 
         // Act
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(double_func)
             .Add(square)
             .Add(addTen)
@@ -85,7 +85,7 @@ public class DelegateCapabilityTests
         Action<int> intAction = num => intMessages.Add(num);
 
         // Act
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(stringAction)
             .Add(intAction)
             .Build();
@@ -120,11 +120,11 @@ public class DelegateCapabilityTests
         var subject = new StringSubject("test");
 
         Func<string, int> getLength = s => s.Length;
-        Func<int, string> toString = i => i.ToString();
+        Func<int, string> toString = i => i.ToString(System.Globalization.CultureInfo.InvariantCulture);
         Func<string, string> toUpper = s => s.ToUpper();
 
         // Act
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(getLength)
             .Add(toString)
             .Add(toUpper)
@@ -157,7 +157,7 @@ public class DelegateCapabilityTests
         Action<string> action3 = msg => messages.Add($"Third: {msg}");
 
         // Act - Add in non-sequential order but with explicit ordering
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(action2, order: 20)
             .Add(action1, order: 10)
             .Add(action3, order: 30)
@@ -189,7 +189,7 @@ public class DelegateCapabilityTests
         Action<string> action2 = msg => { };
 
         // Act
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(action1)
             .Add(action2)
             .Build();
@@ -213,7 +213,7 @@ public class DelegateCapabilityTests
         Func<int, int> second = x => x * 3;
 
         // Act
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(first)
             .Add(second)
             .Build();
@@ -238,7 +238,7 @@ public class DelegateCapabilityTests
         Action<string> action = msg => invoked = true;
 
         // Act
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .AddAs<Action<string>>(action)
             .Build();
 
@@ -263,7 +263,7 @@ public class DelegateCapabilityTests
         Func<string, string> addPrefix = s => $"PROCESSED: {s}";
 
         // Act
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(trim, order: 10)
             .Add(toUpper, order: 20)
             .Add(addPrefix, order: 30)
@@ -296,7 +296,7 @@ public class DelegateCapabilityTests
         Func<string, bool> hasMaxLength = s => s.Length <= 10;
 
         // Act
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(notEmpty)
             .Add(hasMinLength)
             .Add(hasMaxLength)
@@ -327,7 +327,7 @@ public class DelegateCapabilityTests
         Action<string> action = msg => counter++;
 
         // Act
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(action)
             .TryAdd(action) // Should not add duplicate
             .Build();

--- a/src/Cocoar.Capabilities.Tests/FuncOrderingTests.cs
+++ b/src/Cocoar.Capabilities.Tests/FuncOrderingTests.cs
@@ -22,7 +22,7 @@ public class FuncOrderingTests
         var cap3 = new HasOrder { Order = 200 };
 
         // Act
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(cap1, c => ((HasOrder)c).Order)
             .Add(cap2, c => ((HasOrder)c).Order)
             .Add(cap3, c => ((HasOrder)c).Order)
@@ -47,7 +47,7 @@ public class FuncOrderingTests
         var cap3 = new HasOrder { Order = 20 };
 
         // Act
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .AddAs<object>(cap1, c => ((HasOrder)c).Order)
             .AddAs<object>(cap2, c => ((HasOrder)c).Order)
             .AddAs<object>(cap3, c => ((HasOrder)c).Order)
@@ -70,7 +70,7 @@ public class FuncOrderingTests
         var cap1 = new HasOrder { Order = 5 };
 
         // Act - Only first TryAdd succeeds since type already exists
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .TryAdd(cap1, c => ((HasOrder)c).Order)
             .Build();
 
@@ -89,7 +89,7 @@ public class FuncOrderingTests
         var cap1 = new HasOrder { Order = 40 };
 
         // Act - Only first TryAddAs succeeds since type already exists
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .TryAddAs<object>(cap1, c => ((HasOrder)c).Order)
             .Build();
 
@@ -110,7 +110,7 @@ public class FuncOrderingTests
         var cap3 = new HasOrder { Order = 3 };
 
         // Act - reverse the order
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(cap1, c => -((HasOrder)c).Order)
             .Add(cap2, c => -((HasOrder)c).Order)
             .Add(cap3, c => -((HasOrder)c).Order)

--- a/src/Cocoar.Capabilities.Tests/GetFirstTests.cs
+++ b/src/Cocoar.Capabilities.Tests/GetFirstTests.cs
@@ -10,7 +10,7 @@ public class GetFirstTests
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("test");
 
-        var composition = scope.For(subject).Build();
+        var composition = scope.Compose(subject).Build();
 
         var result = composition.GetFirstOrDefault<TestCapability>();
 
@@ -24,7 +24,7 @@ public class GetFirstTests
         var subject = new StringSubject("test");
 
         var capability = new TestCapability("First");
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(capability)
             .Build();
 
@@ -41,7 +41,7 @@ public class GetFirstTests
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("test");
 
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(new TestCapability("Third"), order: 30)
             .Add(new TestCapability("First"), order: 10)
             .Add(new TestCapability("Second"), order: 20)
@@ -59,7 +59,7 @@ public class GetFirstTests
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("test");
 
-        var composition = scope.For(subject).Build();
+        var composition = scope.Compose(subject).Build();
 
         var found = composition.TryGetFirst<TestCapability>(out var result);
 
@@ -74,7 +74,7 @@ public class GetFirstTests
         var subject = new StringSubject("test");
 
         var capability = new TestCapability("Only");
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(capability)
             .Build();
 
@@ -92,7 +92,7 @@ public class GetFirstTests
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("test");
 
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(new TestCapability("C"), order: 3)
             .Add(new TestCapability("A"), order: 1)
             .Add(new TestCapability("B"), order: 2)
@@ -111,7 +111,7 @@ public class GetFirstTests
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("test");
 
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(new TestCapability("TestCap"))
             .Add(new DocumentCapability("DocType", "Content"))
             .Build();
@@ -136,7 +136,7 @@ public class GetFirstTests
         using var scope = new CapabilityScope(options);
         var subject = new StringSubject("registry-test");
 
-        var composition = scope.For(subject, useRegistry: true)
+        var composition = scope.Compose(subject, useRegistry: true)
             .Add(new TestCapability("First"))
             .Add(new TestCapability("Second"))
             .Build(useRegistry: true);
@@ -156,7 +156,7 @@ public class GetFirstTests
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("test");
 
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(new TestCapability("FirstAdded"))
             .Add(new TestCapability("SecondAdded"))
             .Add(new TestCapability("ThirdAdded"))
@@ -174,7 +174,7 @@ public class GetFirstTests
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("test");
 
-        var composition = scope.For(subject).Build();
+        var composition = scope.Compose(subject).Build();
 
         var ex = Assert.Throws<InvalidOperationException>(() => 
             composition.GetRequiredFirst<TestCapability>());
@@ -189,7 +189,7 @@ public class GetFirstTests
         var subject = new StringSubject("test");
 
         var capability = new TestCapability("Required");
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(capability)
             .Build();
 
@@ -206,7 +206,7 @@ public class GetFirstTests
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("test");
 
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(new TestCapability("Z"), order: 30)
             .Add(new TestCapability("A"), order: 10)
             .Add(new TestCapability("M"), order: 20)
@@ -224,7 +224,7 @@ public class GetFirstTests
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("test");
 
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(new TestCapability("TestCap"))
             .Add(new DocumentCapability("DocType", "Content"))
             .Build();

--- a/src/Cocoar.Capabilities.Tests/GetLastTests.cs
+++ b/src/Cocoar.Capabilities.Tests/GetLastTests.cs
@@ -13,7 +13,7 @@ public class GetLastTests
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("test");
 
-        var composition = scope.For(subject).Build();
+        var composition = scope.Compose(subject).Build();
 
         var result = composition.GetLastOrDefault<TestCapability>();
 
@@ -27,7 +27,7 @@ public class GetLastTests
         var subject = new StringSubject("test");
 
         var capability = new TestCapability("only");
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(capability)
             .Build();
 
@@ -46,7 +46,7 @@ public class GetLastTests
         var second = new TestCapability("second");
         var third = new TestCapability("third");
         
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(first)
             .Add(second)
             .Add(third)
@@ -67,7 +67,7 @@ public class GetLastTests
         var testCap = new TestCapability("test");
         var otherCap = new OtherCapability(42);
         
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(testCap)
             .Add(otherCap)
             .Build();
@@ -84,7 +84,7 @@ public class GetLastTests
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("test");
 
-        var composition = scope.For(subject).Build();
+        var composition = scope.Compose(subject).Build();
 
         var ex = Assert.Throws<InvalidOperationException>(
             () => composition.GetRequiredLast<TestCapability>());
@@ -100,7 +100,7 @@ public class GetLastTests
         var subject = new StringSubject("test");
 
         var capability = new TestCapability("only");
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(capability)
             .Build();
 
@@ -119,7 +119,7 @@ public class GetLastTests
         var second = new TestCapability("second");
         var third = new TestCapability("third");
         
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(first)
             .Add(second)
             .Add(third)
@@ -140,7 +140,7 @@ public class GetLastTests
         var testCap = new TestCapability("test");
         var otherCap = new OtherCapability(42);
         
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(testCap)
             .Add(otherCap)
             .Build();
@@ -157,7 +157,7 @@ public class GetLastTests
         using var scope = new CapabilityScope(TestOptions.Disabled);
         var subject = new StringSubject("test");
 
-        var composition = scope.For(subject).Build();
+        var composition = scope.Compose(subject).Build();
 
         var result = composition.TryGetLast<TestCapability>(out var capability);
 
@@ -172,7 +172,7 @@ public class GetLastTests
         var subject = new StringSubject("test");
 
         var expected = new TestCapability("only");
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(expected)
             .Build();
 
@@ -192,7 +192,7 @@ public class GetLastTests
         var second = new TestCapability("second");
         var third = new TestCapability("third");
         
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(first)
             .Add(second)
             .Add(third)
@@ -214,7 +214,7 @@ public class GetLastTests
         var testCap = new TestCapability("test");
         var otherCap = new OtherCapability(42);
         
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(testCap)
             .Add(otherCap)
             .Build();
@@ -236,7 +236,7 @@ public class GetLastTests
         var medium = new TestCapability("medium-priority");
         var high = new TestCapability("high-priority");
         
-        var composition = scope.For(subject)
+        var composition = scope.Compose(subject)
             .Add(medium, order: 5)
             .Add(high, order: 10)
             .Add(low, order: 1)

--- a/src/Cocoar.Capabilities.Tests/NegativeInvariantTests.cs
+++ b/src/Cocoar.Capabilities.Tests/NegativeInvariantTests.cs
@@ -11,7 +11,7 @@ public class NegativeInvariantTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("dbl");
-        var composer = scope.For(subject)
+        var composer = scope.Compose(subject)
             .Add(new TestCapability("A"));
         var comp = composer.Build();
         Assert.NotNull(comp);
@@ -23,7 +23,7 @@ public class NegativeInvariantTests
     public void Add_AfterBuild_Throws()
     {
         using var scope = NewScope();
-        var composer = scope.For(new StringSubject("after"))
+        var composer = scope.Compose(new StringSubject("after"))
             .Add(new TestCapability("X"));
         composer.Build();
         var ex = Assert.Throws<InvalidOperationException>(() => composer.Add(new TestCapability("Y")));
@@ -35,27 +35,27 @@ public class NegativeInvariantTests
     {
         var scope = NewScope();
         var subject = new StringSubject("disp");
-        var composer = scope.For(subject).Add(new TestCapability("A"));
+        var composer = scope.Compose(subject).Add(new TestCapability("A"));
         scope.Dispose();
         // Existing composer can still build (current implementation) - treat as allowed invariant
         var comp = composer.Build();
         Assert.NotNull(comp);
         // But creating a new composer after dispose should throw
-        Assert.Throws<ObjectDisposedException>(() => scope.For(new StringSubject("new")));
+        Assert.Throws<ObjectDisposedException>(() => scope.Compose(new StringSubject("new")));
     }
 
     [Fact]
     public void For_NullSubject_Throws()
     {
         using var scope = NewScope();
-        Assert.Throws<ArgumentNullException>(() => scope.For(null!));
+        Assert.Throws<ArgumentNullException>(() => scope.Compose(null!));
     }
 
     [Fact]
     public void Add_NullCapability_Throws()
     {
         using var scope = NewScope();
-        var composer = scope.For(new StringSubject("nullAdd"));
+        var composer = scope.Compose(new StringSubject("nullAdd"));
         Assert.Throws<ArgumentNullException>(() => composer.Add(null!));
     }
 
@@ -63,7 +63,7 @@ public class NegativeInvariantTests
     public void AddAs_NullCapability_Throws()
     {
         using var scope = NewScope();
-        var composer = scope.For(new StringSubject("nullAddAs"));
+        var composer = scope.Compose(new StringSubject("nullAddAs"));
         Assert.Throws<ArgumentNullException>(() => composer.AddAs<ITestContract>(null!));
     }
 
@@ -71,7 +71,7 @@ public class NegativeInvariantTests
     public void TryAdd_NullCapability_Throws()
     {
         using var scope = NewScope();
-        var composer = scope.For(new StringSubject("nullTryAdd"));
+        var composer = scope.Compose(new StringSubject("nullTryAdd"));
         Assert.Throws<ArgumentNullException>(() => composer.TryAdd<TestCapability>(null!));
     }
 
@@ -79,7 +79,7 @@ public class NegativeInvariantTests
     public void TryAddAs_NullCapability_Throws()
     {
         using var scope = NewScope();
-        var composer = scope.For(new StringSubject("nullTryAddAs"));
+        var composer = scope.Compose(new StringSubject("nullTryAddAs"));
         Assert.Throws<ArgumentNullException>(() => composer.TryAddAs<ITestContract>(null!));
     }
 
@@ -87,7 +87,7 @@ public class NegativeInvariantTests
     public void WithPrimary_Null_AfterPrimary_Removes()
     {
         using var scope = NewScope();
-        var comp = scope.For(new StringSubject("primNull"))
+        var comp = scope.Compose(new StringSubject("primNull"))
             .Add(new PrimaryTestCapability("P"))
             .WithPrimary(null)
             .Build();
@@ -99,7 +99,7 @@ public class NegativeInvariantTests
     {
         var scope = NewScope();
         var subject = new StringSubject("life");
-        var comp = scope.For(subject)
+        var comp = scope.Compose(subject)
             .Add(new TestCapability("A"))
             .Add(new TestCapability("B"))
             .Build();
@@ -109,6 +109,6 @@ public class NegativeInvariantTests
         // Snapshot still usable
         Assert.Equal(2, comp.GetAll<TestCapability>().Count);
         // Creating new composer should throw
-        Assert.Throws<ObjectDisposedException>(() => scope.For(new StringSubject("after")));
+        Assert.Throws<ObjectDisposedException>(() => scope.Compose(new StringSubject("after")));
     }
 }

--- a/src/Cocoar.Capabilities.Tests/OrderingTests.cs
+++ b/src/Cocoar.Capabilities.Tests/OrderingTests.cs
@@ -22,7 +22,7 @@ public class OrderingTests
     {
         var scope = new CapabilityScope();
         var subj = new Subject(1);
-        var composer = scope.For(subj);
+        var composer = scope.Compose(subj);
 
         // Intentionally add in unsorted order
         composer.Add(new OrderedCap(1, 50), order: 50);
@@ -43,7 +43,7 @@ public class OrderingTests
     {
         var scope = new CapabilityScope();
         var subj = new Subject(2);
-        var composer = scope.For(subj);
+        var composer = scope.Compose(subj);
 
         // All same priority => resulting order must match insertion order
         composer.Add(new OrderedCap(1, 5), order: 5);
@@ -64,7 +64,7 @@ public class OrderingTests
     {
         var scope = new CapabilityScope();
         var subj = new Subject(3);
-        var composer = scope.For(subj);
+        var composer = scope.Compose(subj);
 
         composer.Add(new PlainCap(1));
         composer.Add(new PlainCap(2));
@@ -83,7 +83,7 @@ public class OrderingTests
     {
         var scope = new CapabilityScope();
         var subj = new Subject(4);
-        var composer = scope.For(subj);
+        var composer = scope.Compose(subj);
 
         // Plain (order defaults to 0)
         composer.Add(new PlainCap(1));           // P1

--- a/src/Cocoar.Capabilities.Tests/OwnerAndAnchorExampleTests.cs
+++ b/src/Cocoar.Capabilities.Tests/OwnerAndAnchorExampleTests.cs
@@ -1,0 +1,214 @@
+using Xunit;
+
+namespace Cocoar.Capabilities.Tests;
+
+/// <summary>
+/// Demonstrates real-world usage scenarios for Owner and Anchor functionality.
+/// These tests serve as both verification and documentation.
+/// </summary>
+public class OwnerAndAnchorExampleTests
+{
+    // Simulated domain objects
+    private class PipelineHost
+    {
+        public string Name { get; init; } = string.Empty;
+    }
+
+    private class EnvironmentContext
+    {
+        public string Environment { get; init; } = string.Empty;
+    }
+
+    private class TenantContext
+    {
+        public string TenantId { get; init; } = string.Empty;
+    }
+
+    private class ConfigurationManager
+    {
+        public Dictionary<string, string> Settings { get; } = new();
+    }
+
+    // Sample capabilities
+    private record DiagnosticsCapability(bool Enabled);
+    private record EnvironmentCapability(string EnvName);
+    private record TenantCapability(string TenantId);
+    private record ConfigCapability(string Key, string Value);
+
+    [Fact]
+    public void Example_PipelineWithMultipleContexts()
+    {
+        // Scenario: A pipeline framework where the scope is associated with
+        // multiple contextual objects that need capabilities
+
+        using var scope = new CapabilityScope();
+
+        var pipeline = new PipelineHost { Name = "DataPipeline" };
+        var env = new EnvironmentContext { Environment = "Production" };
+        var tenant = new TenantContext { TenantId = "tenant-123" };
+
+        // Initialize scope with owner and anchors
+        scope.Owner.Set(pipeline);
+        scope.Anchors
+         .Set(env);
+        scope.Anchors
+        .Set("tenant", tenant);
+
+        // Later, with only scope available, compose capabilities for different subjects
+
+        // Add diagnostics to the pipeline itself
+        scope.Owner.Compose<PipelineHost>()
+             .Add(new DiagnosticsCapability(true))
+             .Build();
+
+        // Add environment-specific capability
+        scope.Anchors.Compose<EnvironmentContext>()
+             .Add(new EnvironmentCapability("Production"))
+             .Build();
+
+        // Add tenant-specific capability
+        scope.Anchors.Compose("tenant")
+             .Add(new TenantCapability("tenant-123"))
+             .Build();
+
+        // Verify all compositions exist
+        var pipelineComp = scope.Compositions.GetOrDefault(pipeline);
+        var envComp = scope.Compositions.GetOrDefault(env);
+        var tenantComp = scope.Compositions.GetOrDefault(tenant);
+
+        Assert.NotNull(pipelineComp);
+        Assert.NotNull(envComp);
+        Assert.NotNull(tenantComp);
+
+        Assert.True(pipelineComp!.GetAll<DiagnosticsCapability>()[0].Enabled);
+        Assert.Equal("Production", envComp!.GetAll<EnvironmentCapability>()[0].EnvName);
+        Assert.Equal("tenant-123", tenantComp!.GetAll<TenantCapability>()[0].TenantId);
+    }
+
+    [Fact]
+    public void Example_ConfigurationSystemWithOwner()
+    {
+        // Scenario: A configuration system where the manager owns the scope
+
+        using var scope = new CapabilityScope();
+        var configManager = new ConfigurationManager();
+        configManager.Settings["LogLevel"] = "Debug";
+        configManager.Settings["Timeout"] = "30";
+
+        scope.Owner.Set(configManager);
+
+        // Extension code receives only the scope
+        EnrichConfiguration(scope);
+
+        // Verify capabilities were added to the config manager
+        var composition = scope.Compositions.GetOrDefault(configManager);
+        Assert.NotNull(composition);
+
+        var configs = composition!.GetAll<ConfigCapability>();
+        Assert.Equal(2, configs.Count);
+    }
+
+    // Helper method that only receives the scope, not the manager
+    private static void EnrichConfiguration(CapabilityScope scope)
+    {
+        var manager = scope.Owner.Get<ConfigurationManager>();
+
+        var composer = scope.Owner.Compose();
+        foreach (var setting in manager.Settings)
+        {
+            composer.Add(new ConfigCapability(setting.Key, setting.Value));
+        }
+        composer.Build();
+    }
+
+    [Fact]
+    public void Example_MultiTenantPlatform()
+    {
+        // Scenario: Multi-tenant platform where each scope represents a tenant session
+
+        using var scope = new CapabilityScope();
+
+        var tenant1 = new TenantContext { TenantId = "acme-corp" };
+        var tenant2 = new TenantContext { TenantId = "globex-inc" };
+
+        scope.Owner.Set(tenant1);
+            scope.Anchors
+             .Set("primary-tenant", tenant1)
+             .Set("secondary-tenant", tenant2);
+
+        // Compose for primary tenant (owner)
+        scope.Owner.Compose<TenantContext>()
+             .Add(new TenantCapability("acme-corp"))
+             .Build();
+
+        // Compose for secondary tenant (anchor)
+        scope.Anchors.Compose("secondary-tenant")
+             .Add(new TenantCapability("globex-inc"))
+             .Build();
+
+        var primary = scope.Compositions.GetOrDefault(tenant1);
+        var secondary = scope.Compositions.GetOrDefault(tenant2);
+
+        Assert.NotNull(primary);
+        Assert.NotNull(secondary);
+        Assert.Equal("acme-corp", primary!.GetAll<TenantCapability>()[0].TenantId);
+        Assert.Equal("globex-inc", secondary!.GetAll<TenantCapability>()[0].TenantId);
+    }
+
+    [Fact]
+    public void Example_WorkflowEngineWithNamedAnchors()
+    {
+        // Scenario: Workflow engine with multiple named contexts
+
+        using var scope = new CapabilityScope();
+
+        var workflowDef = new { Name = "OrderProcessing", Version = "1.0" };
+        var executionCtx = new { ExecutionId = "exec-456", StartTime = DateTime.UtcNow };
+
+        scope.Owner.Set(workflowDef);
+            scope.Anchors
+             .Set("execution", executionCtx);
+             scope.Anchors
+             .Set("environment", new EnvironmentContext { Environment = "Staging" });
+
+        // Compose for execution context using named anchor
+        scope.Anchors.Compose("execution")
+             .Add(new DiagnosticsCapability(true))
+             .Build();
+
+        // Compose for environment using named anchor
+        scope.Anchors.Compose("environment")
+             .Add(new EnvironmentCapability("Staging"))
+             .Build();
+
+        var execComp = scope.Compositions.GetOrDefault(executionCtx);
+        Assert.NotNull(execComp);
+        Assert.True(execComp!.GetAll<DiagnosticsCapability>()[0].Enabled);
+    }
+
+    [Fact]
+    public void Example_FluentChainingForSetup()
+    {
+        // Demonstrate fluent API for scope initialization
+
+        using var scope = new CapabilityScope();
+
+        var host = new PipelineHost { Name = "Main" };
+        var env = new EnvironmentContext { Environment = "Dev" };
+        var config = new ConfigurationManager();
+
+        // All setup in one fluent chain
+        scope.Owner.Set(host);
+            scope.Anchors.Set(env)
+            .Set(config)
+            .Set("app-name", "MyApp")
+            .Set("version", "2.0.0");
+
+        // Verify all are accessible
+        Assert.Same(host, scope.Owner.Get<PipelineHost>());
+        Assert.True(scope.Anchors.TryGet<EnvironmentContext>(out var e) && e == env);
+        Assert.True(scope.Anchors.TryGet<ConfigurationManager>(out var c) && c == config);
+        Assert.True(scope.Anchors.TryGet("app-name", out var appName) && appName?.Equals("MyApp") == true);
+        Assert.True(scope.Anchors.TryGet("version", out var ver) && ver?.Equals("2.0.0") == true);
+    }
+}

--- a/src/Cocoar.Capabilities.Tests/OwnerAndAnchorExtensionTests.cs
+++ b/src/Cocoar.Capabilities.Tests/OwnerAndAnchorExtensionTests.cs
@@ -1,0 +1,307 @@
+using Xunit;
+
+namespace Cocoar.Capabilities.Tests;
+
+public class OwnerAndAnchorExtensionTests
+{
+    private class TestOwner
+    {
+        public string Name { get; init; } = string.Empty;
+    }
+
+    private class TestAnchor
+    {
+        public int Value { get; init; }
+    }
+
+    private record TestCapability(string Data);
+
+    #region ComposeOwner Tests
+
+    [Fact]
+    public void ComposeOwner_ReturnsComposerForOwner()
+    {
+        using var scope = new CapabilityScope();
+        var owner = new TestOwner { Name = "Owner1" };
+        scope.Owner.Set(owner);
+
+        var composer = scope.Owner.Compose();
+
+        Assert.NotNull(composer);
+
+        // Verify we can build a composition
+        var composition = composer.Add(new TestCapability("test")).Build();
+        Assert.NotNull(composition);
+        Assert.Single(composition.GetAll<TestCapability>());
+    }
+
+    [Fact]
+    public void ComposeOwner_ThrowsWhenNoOwnerSet()
+    {
+        using var scope = new CapabilityScope();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => scope.Owner.Compose());
+        Assert.Contains("No owner has been set", ex.Message);
+    }
+
+    [Fact]
+    public void ComposeOwner_Generic_ReturnsComposerForTypedOwner()
+    {
+        using var scope = new CapabilityScope();
+        var owner = new TestOwner { Name = "TypedOwner" };
+        scope.Owner.Set(owner);
+
+        var composer = scope.Owner.Compose<TestOwner>();
+
+        Assert.NotNull(composer);
+
+        // Verify composition works
+        var composition = composer.Add(new TestCapability("typed")).Build();
+        Assert.NotNull(composition);
+        Assert.Single(composition.GetAll<TestCapability>());
+    }
+
+    [Fact]
+    public void ComposeOwner_Generic_ThrowsWhenNoOwnerSet()
+    {
+        using var scope = new CapabilityScope();
+
+        Assert.Throws<InvalidOperationException>(() => scope.Owner.Compose<TestOwner>());
+    }
+
+    [Fact]
+    public void ComposeOwner_Generic_ThrowsWhenWrongType()
+    {
+        using var scope = new CapabilityScope();
+        scope.Owner.Set(new TestOwner());
+
+        Assert.Throws<InvalidCastException>(() => scope.Owner.Compose<TestAnchor>());
+    }
+
+    [Fact]
+    public void ComposeOwner_WithUseRegistry_PassesParameterThrough()
+    {
+        using var scope = new CapabilityScope();
+        var owner = new TestOwner { Name = "RegistryTest" };
+        scope.Owner.Set(owner);
+
+        var composer = scope.Owner.Compose(useRegistry: false);
+        var composition = composer.Add(new TestCapability("reg-test")).Build(useRegistry: false);
+
+        // Verify composition was not registered
+        var found = scope.Compositions.GetOrDefault(owner);
+        Assert.Null(found);
+    }
+
+    #endregion
+
+    #region ComposeAnchor Typed Tests
+
+    [Fact]
+    public void ComposeAnchor_Generic_ReturnsComposerForAnchor()
+    {
+        using var scope = new CapabilityScope();
+        var anchor = new TestAnchor { Value = 42 };
+        scope.Anchors.Set(anchor);
+
+        var composer = scope.Anchors.Compose<TestAnchor>();
+
+        Assert.NotNull(composer);
+
+        // Verify composition works
+        var composition = composer.Add(new TestCapability("anchor-test")).Build();
+        Assert.NotNull(composition);
+        Assert.Single(composition.GetAll<TestCapability>());
+    }
+
+    [Fact]
+    public void ComposeAnchor_Generic_ThrowsWhenAnchorNotSet()
+    {
+        using var scope = new CapabilityScope();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => scope.Anchors.Compose<TestAnchor>());
+        Assert.Contains("No anchor of type TestAnchor", ex.Message);
+    }
+
+    [Fact]
+    public void ComposeAnchor_Generic_WithUseRegistry_PassesParameterThrough()
+    {
+        using var scope = new CapabilityScope();
+        var anchor = new TestAnchor { Value = 100 };
+        scope.Anchors.Set(anchor);
+
+        var composer = scope.Anchors.Compose<TestAnchor>(useRegistry: false);
+        var composition = composer.Add(new TestCapability("no-reg")).Build(useRegistry: false);
+
+        // Verify composition was not registered
+        var found = scope.Compositions.GetOrDefault(anchor);
+        Assert.Null(found);
+    }
+
+    #endregion
+
+    #region ComposeAnchor Named Tests
+
+    [Fact]
+    public void ComposeAnchor_Named_ReturnsComposerForAnchor()
+    {
+        using var scope = new CapabilityScope();
+        var anchor = new TestAnchor { Value = 999 };
+        scope.Anchors.Set("environment", anchor);
+
+        var composer = scope.Anchors.Compose("environment");
+
+        Assert.NotNull(composer);
+
+        // Verify composition works
+        var composition = composer.Add(new TestCapability("env-test")).Build();
+        Assert.NotNull(composition);
+        Assert.Single(composition.GetAll<TestCapability>());
+    }
+
+    [Fact]
+    public void ComposeAnchor_Named_ThrowsWhenAnchorNotSet()
+    {
+        using var scope = new CapabilityScope();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => scope.Anchors.Compose("missing-key"));
+        Assert.Contains("No anchor with key 'missing-key'", ex.Message);
+    }
+
+    [Fact]
+    public void ComposeAnchor_Named_ThrowsOnNullKey()
+    {
+        using var scope = new CapabilityScope();
+
+        Assert.Throws<ArgumentNullException>(() => scope.Anchors.Compose(null!));
+    }
+
+    [Fact]
+    public void ComposeAnchor_Named_WithUseRegistry_PassesParameterThrough()
+    {
+        using var scope = new CapabilityScope();
+        var anchor = new TestAnchor { Value = 777 };
+        scope.Anchors.Set("pipeline", anchor);
+
+        var composer = scope.Anchors.Compose("pipeline", useRegistry: false);
+        var composition = composer.Add(new TestCapability("pipeline-test")).Build(useRegistry: false);
+
+        // Verify composition was not registered
+        var found = scope.Compositions.GetOrDefault(anchor);
+        Assert.Null(found);
+    }
+
+    #endregion
+
+    #region Integration Tests
+
+    [Fact]
+    public void Integration_OwnerAndAnchors_CanComposeSeparately()
+    {
+        using var scope = new CapabilityScope();
+        var owner = new TestOwner { Name = "MainOwner" };
+        var anchor1 = new TestAnchor { Value = 1 };
+        var anchor2 = new TestAnchor { Value = 2 };
+
+        scope.Owner.Set(owner);
+        scope.Anchors
+            .Set(anchor1)
+            .Set("secondary", anchor2);
+
+        // Compose for owner
+        var ownerComposition = scope.Owner.Compose()
+            .Add(new TestCapability("owner-cap"))
+            .Build();
+
+        // Compose for typed anchor
+        var anchor1Composition = scope.Anchors.Compose<TestAnchor>()
+            .Add(new TestCapability("anchor1-cap"))
+            .Build();
+
+        // Compose for named anchor
+        var anchor2Composition = scope.Anchors.Compose("secondary")
+            .Add(new TestCapability("anchor2-cap"))
+            .Build();
+
+        // Verify all compositions are distinct
+        Assert.NotSame(ownerComposition, anchor1Composition);
+        Assert.NotSame(ownerComposition, anchor2Composition);
+        Assert.NotSame(anchor1Composition, anchor2Composition);
+
+        // Verify capabilities
+        Assert.Equal("owner-cap", ownerComposition.GetAll<TestCapability>()[0].Data);
+        Assert.Equal("anchor1-cap", anchor1Composition.GetAll<TestCapability>()[0].Data);
+        Assert.Equal("anchor2-cap", anchor2Composition.GetAll<TestCapability>()[0].Data);
+    }
+
+    [Fact]
+    public void Integration_MultipleCapabilitiesForOwner()
+    {
+        using var scope = new CapabilityScope();
+        var owner = new TestOwner { Name = "MultiCapOwner" };
+        scope.Owner.Set(owner);
+
+        var composition = scope.Owner.Compose()
+            .Add(new TestCapability("cap1"))
+            .Add(new TestCapability("cap2"))
+            .Add(new TestCapability("cap3"))
+            .Build();
+
+        var capabilities = composition.GetAll<TestCapability>();
+        Assert.Equal(3, capabilities.Count);
+        Assert.Contains(capabilities, c => c.Data == "cap1");
+        Assert.Contains(capabilities, c => c.Data == "cap2");
+        Assert.Contains(capabilities, c => c.Data == "cap3");
+    }
+
+    [Fact]
+    public void Integration_RecomposingOwnerComposition()
+    {
+        using var scope = new CapabilityScope();
+        var owner = new TestOwner { Name = "RecomposeOwner" };
+        scope.Owner.Set(owner);
+
+        // Initial composition
+        var composition1 = scope.Owner.Compose()
+            .Add(new TestCapability("initial"))
+            .Build();
+
+        // Recompose
+        var composition2 = scope.Recompose(composition1)
+            .Add(new TestCapability("added"))
+            .Build();
+
+        var capabilities = composition2.GetAll<TestCapability>();
+        Assert.Equal(2, capabilities.Count);
+        Assert.Contains(capabilities, c => c.Data == "initial");
+        Assert.Contains(capabilities, c => c.Data == "added");
+    }
+
+    [Fact]
+    public void Integration_OwnerAndAnchorsSameObject()
+    {
+        using var scope = new CapabilityScope();
+        var obj = new TestOwner { Name = "SharedObject" };
+
+        // Set same object as owner and typed anchor
+        scope.Owner.Set(obj)
+            .Scope
+            .Anchors.Set(obj);
+
+        // Both should return composers for the same subject
+        var ownerComposer = scope.Owner.Compose<TestOwner>();
+        var anchorComposer = scope.Anchors.Compose<TestOwner>();
+
+        // Build separate compositions
+        var comp1 = ownerComposer.Add(new TestCapability("from-owner")).Build();
+        var comp2 = anchorComposer.Add(new TestCapability("from-anchor")).Build();
+
+        // They should be different compositions but for same subject
+        Assert.NotSame(comp1, comp2);
+
+        // But the subject should be the same
+        Assert.Same(comp1.Subject, comp2.Subject);
+    }
+
+    #endregion
+}

--- a/src/Cocoar.Capabilities.Tests/OwnerAndAnchorTests.cs
+++ b/src/Cocoar.Capabilities.Tests/OwnerAndAnchorTests.cs
@@ -1,0 +1,617 @@
+using Xunit;
+
+namespace Cocoar.Capabilities.Tests;
+
+public class OwnerAndAnchorTests
+{
+    private class TestOwner
+    {
+        public string Name { get; init; } = string.Empty;
+    }
+
+    private class TestAnchor
+    {
+        public int Value { get; init; }
+    }
+
+    private class AnotherAnchor
+    {
+        public bool Flag { get; init; }
+    }
+
+    private record TestCapability(string Name);
+
+    #region Owner Tests
+
+    [Fact]
+    public void SetOwner_SetsOwnerSuccessfully()
+    {
+        using var scope = new CapabilityScope();
+        var owner = new TestOwner { Name = "TestOwner" };
+
+        var result = scope.Owner.Set(owner);
+
+        Assert.Same(scope, result.Scope); // Fluent API
+        Assert.True(scope.Owner.TryGet<TestOwner>(out var retrieved));
+        Assert.Same(owner, retrieved);
+    }
+
+    [Fact]
+    public void SetOwner_ThrowsOnNull()
+    {
+        using var scope = new CapabilityScope();
+        
+        Assert.Throws<ArgumentNullException>(() => scope.Owner.Set(null!));
+    }
+
+    [Fact]
+    public void SetOwner_ThrowsWhenOwnerAlreadySet()
+    {
+        using var scope = new CapabilityScope();
+        var owner1 = new TestOwner { Name = "First" };
+        var owner2 = new TestOwner { Name = "Second" };
+        
+        scope.Owner.Set(owner1);
+        
+        var ex = Assert.Throws<InvalidOperationException>(() => scope.Owner.Set(owner2));
+        Assert.Contains("already been set", ex.Message);
+        Assert.Contains("Replace()", ex.Message);
+    }
+
+    [Fact]
+    public void SetOwner_AllowsSettingAfterGarbageCollected()
+    {
+        using var scope = new CapabilityScope();
+        SetOwnerAndCollect(scope);
+        
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        
+        // Should allow setting a new owner after the old one was GC'd
+        var newOwner = new TestOwner { Name = "NewOwner" };
+        scope.Owner.Set(newOwner);
+        
+        Assert.Same(newOwner, scope.Owner.Get<TestOwner>());
+    }
+
+    [Fact]
+    public void ReplaceOwner_ReplacesExistingOwner()
+    {
+        using var scope = new CapabilityScope();
+        var owner1 = new TestOwner { Name = "First" };
+        var owner2 = new TestOwner { Name = "Second" };
+        
+        scope.Owner.Set(owner1);
+        scope.Owner.Replace(owner2);
+        
+        Assert.Same(owner2, scope.Owner.Get<TestOwner>());
+    }
+
+    [Fact]
+    public void ReplaceOwner_WorksWhenNoOwnerSet()
+    {
+        using var scope = new CapabilityScope();
+        var owner = new TestOwner { Name = "Owner" };
+        
+        scope.Owner.Replace(owner);
+        
+        Assert.Same(owner, scope.Owner.Get<TestOwner>());
+    }
+
+    [Fact]
+    public void ReplaceOwner_ThrowsOnNull()
+    {
+        using var scope = new CapabilityScope();
+        
+        Assert.Throws<ArgumentNullException>(() => scope.Owner.Replace(null!));
+    }
+
+    [Fact]
+    public void Owner_Generic_ReturnsCorrectType()
+    {
+        using var scope = new CapabilityScope();
+        var owner = new TestOwner { Name = "Owner1" };
+        scope.Owner.Set(owner);
+
+        var retrieved = scope.Owner.Get<TestOwner>();
+
+        Assert.Same(owner, retrieved);
+        Assert.Equal("Owner1", retrieved.Name);
+    }
+
+    [Fact]
+    public void Owner_Generic_ThrowsWhenNotSet()
+    {
+        using var scope = new CapabilityScope();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => scope.Owner.Get<TestOwner>());
+        Assert.Contains("No owner has been set", ex.Message);
+    }
+
+    [Fact]
+    public void Owner_Generic_ThrowsWhenWrongType()
+    {
+        using var scope = new CapabilityScope();
+        var owner = new TestOwner();
+        scope.Owner.Set(owner);
+
+        var ex = Assert.Throws<InvalidCastException>(() => scope.Owner.Get<TestAnchor>());
+        Assert.Contains("TestOwner", ex.Message);
+        Assert.Contains("TestAnchor", ex.Message);
+    }
+
+    [Fact]
+    public void Owner_Generic_ThrowsWhenDisposed()
+    {
+        var scope = new CapabilityScope();
+        scope.Owner.Set(new TestOwner());
+        scope.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => scope.Owner.Get<TestOwner>());
+    }
+
+    [Fact]
+    public void TryGetOwner_ReturnsTrueWhenSet()
+    {
+        using var scope = new CapabilityScope();
+        var owner = new TestOwner { Name = "Owner2" };
+        scope.Owner.Set(owner);
+
+        var result = scope.Owner.TryGet<TestOwner>(out var retrieved);
+
+        Assert.True(result);
+        Assert.Same(owner, retrieved);
+    }
+
+    [Fact]
+    public void TryGetOwner_ReturnsFalseWhenNotSet()
+    {
+        using var scope = new CapabilityScope();
+
+        var result = scope.Owner.TryGet<TestOwner>(out var retrieved);
+
+        Assert.False(result);
+        Assert.Null(retrieved);
+    }
+
+    [Fact]
+    public void TryGetOwner_ReturnsFalseWhenWrongType()
+    {
+        using var scope = new CapabilityScope();
+        var owner = new TestOwner();
+        scope.Owner.Set(owner);
+
+        var result = scope.Owner.TryGet<TestAnchor>(out var retrieved);
+
+        Assert.False(result);
+        Assert.Null(retrieved);
+    }
+
+    [Fact]
+    public void TryGetOwner_ThrowsWhenDisposed()
+    {
+        var scope = new CapabilityScope();
+        scope.Owner.Set(new TestOwner());
+        scope.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => scope.Owner.TryGet<TestOwner>(out _));
+    }
+
+    [Fact]
+    public void Owner_ThrowsWhenCollected()
+    {
+        using var scope = new CapabilityScope();
+        SetOwnerAndCollect(scope);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => scope.Owner.Get<TestOwner>());
+        Assert.Contains("garbage collected", ex.Message);
+    }
+
+    [Fact]
+    public void TryGetOwner_ReturnsFalseWhenCollected()
+    {
+        using var scope = new CapabilityScope();
+        SetOwnerAndCollect(scope);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var result = scope.Owner.TryGet<TestOwner>(out var retrieved);
+
+        Assert.False(result);
+        Assert.Null(retrieved);
+    }
+
+    // Helper method to ensure owner is not kept alive by the stack
+    private static void SetOwnerAndCollect(CapabilityScope scope)
+    {
+        scope.Owner.Set(new TestOwner { Name = "Temporary" });
+    }
+
+    #endregion
+
+    #region Typed Anchor Tests
+
+    [Fact]
+    public void SetAnchor_Generic_SetsAnchorSuccessfully()
+    {
+        using var scope = new CapabilityScope();
+        var anchor = new TestAnchor { Value = 42 };
+
+        var result = scope.Anchors.Set(anchor);
+
+        Assert.Same(scope, result.Scope); // Fluent API
+        Assert.True(scope.Anchors.TryGet<TestAnchor>(out var retrieved));
+        Assert.Same(anchor, retrieved);
+    }
+
+    [Fact]
+    public void SetAnchor_Generic_ThrowsOnNull()
+    {
+        using var scope = new CapabilityScope();
+        
+        Assert.Throws<ArgumentNullException>(() => scope.Anchors.Set<TestAnchor>(null!));
+    }
+
+    [Fact]
+    public void SetAnchor_Generic_ThrowsWhenDisposed()
+    {
+        var scope = new CapabilityScope();
+        scope.Dispose();
+        
+        Assert.Throws<ObjectDisposedException>(() => scope.Anchors.Set(new TestAnchor()));
+    }
+
+    [Fact]
+    public void SetAnchor_Generic_SupportsMultipleTypes()
+    {
+        using var scope = new CapabilityScope();
+        var anchor1 = new TestAnchor { Value = 42 };
+        var anchor2 = new AnotherAnchor { Flag = true };
+
+        scope.Anchors.Set(anchor1);
+        scope.Anchors.Set(anchor2);
+
+        Assert.True(scope.Anchors.TryGet<TestAnchor>(out var retrieved1));
+        Assert.True(scope.Anchors.TryGet<AnotherAnchor>(out var retrieved2));
+        Assert.Same(anchor1, retrieved1);
+        Assert.Same(anchor2, retrieved2);
+    }
+
+    [Fact]
+    public void SetAnchor_Generic_ReplacesExistingAnchorOfSameType()
+    {
+        using var scope = new CapabilityScope();
+        var anchor1 = new TestAnchor { Value = 1 };
+        var anchor2 = new TestAnchor { Value = 2 };
+
+        scope.Anchors.Set(anchor1);
+        scope.Anchors.Set(anchor2);
+
+        var retrieved = scope.Anchors.GetOrThrow<TestAnchor>();
+        Assert.Same(anchor2, retrieved);
+        Assert.Equal(2, retrieved.Value);
+    }
+
+    [Fact]
+    public void GetAnchorOrThrow_Generic_ReturnsCorrectType()
+    {
+        using var scope = new CapabilityScope();
+        var anchor = new TestAnchor { Value = 100 };
+        scope.Anchors.Set(anchor);
+
+        var retrieved = scope.Anchors.GetOrThrow<TestAnchor>();
+
+        Assert.Same(anchor, retrieved);
+        Assert.Equal(100, retrieved.Value);
+    }
+
+    [Fact]
+    public void GetAnchorOrThrow_Generic_ThrowsWhenNotSet()
+    {
+        using var scope = new CapabilityScope();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => scope.Anchors.GetOrThrow<TestAnchor>());
+        Assert.Contains("No anchor of type TestAnchor", ex.Message);
+    }
+
+    [Fact]
+    public void GetAnchorOrThrow_Generic_ThrowsWhenDisposed()
+    {
+        var scope = new CapabilityScope();
+        scope.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => scope.Anchors.GetOrThrow<TestAnchor>());
+    }
+
+    [Fact]
+    public void TryGetAnchor_Generic_ReturnsTrueWhenSet()
+    {
+        using var scope = new CapabilityScope();
+        var anchor = new TestAnchor { Value = 200 };
+        scope.Anchors.Set(anchor);
+
+        var result = scope.Anchors.TryGet<TestAnchor>(out var retrieved);
+
+        Assert.True(result);
+        Assert.Same(anchor, retrieved);
+    }
+
+    [Fact]
+    public void TryGetAnchor_Generic_ReturnsFalseWhenNotSet()
+    {
+        using var scope = new CapabilityScope();
+
+        var result = scope.Anchors.TryGet<TestAnchor>(out var retrieved);
+
+        Assert.False(result);
+        Assert.Null(retrieved);
+    }
+
+    [Fact]
+    public void TryGetAnchor_Generic_ThrowsWhenDisposed()
+    {
+        var scope = new CapabilityScope();
+        scope.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => scope.Anchors.TryGet<TestAnchor>(out _));
+    }
+
+    [Fact]
+    public void GetAnchorOrThrow_Generic_ThrowsWhenCollected()
+    {
+        using var scope = new CapabilityScope();
+        SetAnchorAndCollect(scope);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => scope.Anchors.GetOrThrow<TestAnchor>());
+        Assert.Contains("garbage collected", ex.Message);
+    }
+
+    [Fact]
+    public void TryGetAnchor_Generic_ReturnsFalseWhenCollected()
+    {
+        using var scope = new CapabilityScope();
+        SetAnchorAndCollect(scope);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var result = scope.Anchors.TryGet<TestAnchor>(out var retrieved);
+
+        Assert.False(result);
+        Assert.Null(retrieved);
+    }
+
+    private static void SetAnchorAndCollect(CapabilityScope scope)
+    {
+        scope.Anchors.Set(new TestAnchor { Value = 999 });
+    }
+
+    #endregion
+
+    #region Named Anchor Tests
+
+    [Fact]
+    public void SetAnchor_Named_SetsAnchorSuccessfully()
+    {
+        using var scope = new CapabilityScope();
+        var anchor = new TestAnchor { Value = 42 };
+
+        var result = scope.Anchors.Set("test-key", anchor);
+
+        Assert.Same(scope, result.Scope); // Fluent API
+        Assert.True(scope.Anchors.TryGet("test-key", out var retrieved));
+        Assert.Same(anchor, retrieved);
+    }
+
+    [Fact]
+    public void SetAnchor_Named_ThrowsOnNullKey()
+    {
+        using var scope = new CapabilityScope();
+        
+        Assert.Throws<ArgumentNullException>(() => scope.Anchors.Set(null!, new TestAnchor()));
+    }
+
+    [Fact]
+    public void SetAnchor_Named_ThrowsOnNullAnchor()
+    {
+        using var scope = new CapabilityScope();
+        
+        Assert.Throws<ArgumentNullException>(() => scope.Anchors.Set("key", null!));
+    }
+
+    [Fact]
+    public void SetAnchor_Named_ThrowsWhenDisposed()
+    {
+        var scope = new CapabilityScope();
+        scope.Dispose();
+        
+        Assert.Throws<ObjectDisposedException>(() => scope.Anchors.Set("key", new TestAnchor()));
+    }
+
+    [Fact]
+    public void SetAnchor_Named_SupportsMultipleKeys()
+    {
+        using var scope = new CapabilityScope();
+        var anchor1 = new TestAnchor { Value = 1 };
+        var anchor2 = new AnotherAnchor { Flag = true };
+        var anchor3 = new TestOwner { Name = "test" };
+
+        scope.Anchors.Set("key1", anchor1);
+        scope.Anchors.Set("key2", anchor2);
+        scope.Anchors.Set("tenant:acme", anchor3);
+
+        Assert.True(scope.Anchors.TryGet("key1", out var retrieved1));
+        Assert.True(scope.Anchors.TryGet("key2", out var retrieved2));
+        Assert.True(scope.Anchors.TryGet("tenant:acme", out var retrieved3));
+        Assert.Same(anchor1, retrieved1);
+        Assert.Same(anchor2, retrieved2);
+        Assert.Same(anchor3, retrieved3);
+    }
+
+    [Fact]
+    public void SetAnchor_Named_ReplacesExistingAnchorWithSameKey()
+    {
+        using var scope = new CapabilityScope();
+        var anchor1 = new TestAnchor { Value = 1 };
+        var anchor2 = new TestAnchor { Value = 2 };
+
+        scope.Anchors.Set("mykey", anchor1);
+        scope.Anchors.Set("mykey", anchor2);
+
+        var retrieved = scope.Anchors.GetOrThrow("mykey");
+        Assert.Same(anchor2, retrieved);
+    }
+
+    [Fact]
+    public void GetAnchorOrThrow_Named_ReturnsCorrectAnchor()
+    {
+        using var scope = new CapabilityScope();
+        var anchor = new TestAnchor { Value = 100 };
+        scope.Anchors.Set("environment", anchor);
+
+        var retrieved = scope.Anchors.GetOrThrow("environment");
+
+        Assert.Same(anchor, retrieved);
+    }
+
+    [Fact]
+    public void GetAnchorOrThrow_Named_ThrowsOnNullKey()
+    {
+        using var scope = new CapabilityScope();
+        
+        Assert.Throws<ArgumentNullException>(() => scope.Anchors.GetOrThrow(null!));
+    }
+
+    [Fact]
+    public void GetAnchorOrThrow_Named_ThrowsWhenNotSet()
+    {
+        using var scope = new CapabilityScope();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => scope.Anchors.GetOrThrow("missing-key"));
+        Assert.Contains("No anchor with key 'missing-key'", ex.Message);
+    }
+
+    [Fact]
+    public void GetAnchorOrThrow_Named_ThrowsWhenDisposed()
+    {
+        var scope = new CapabilityScope();
+        scope.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => scope.Anchors.GetOrThrow("key"));
+    }
+
+    [Fact]
+    public void TryGetAnchor_Named_ReturnsTrueWhenSet()
+    {
+        using var scope = new CapabilityScope();
+        var anchor = new TestAnchor { Value = 200 };
+        scope.Anchors.Set("pipeline", anchor);
+
+        var result = scope.Anchors.TryGet("pipeline", out var retrieved);
+
+        Assert.True(result);
+        Assert.Same(anchor, retrieved);
+    }
+
+    [Fact]
+    public void TryGetAnchor_Named_ReturnsFalseWhenNotSet()
+    {
+        using var scope = new CapabilityScope();
+
+        var result = scope.Anchors.TryGet("nonexistent", out var retrieved);
+
+        Assert.False(result);
+        Assert.Null(retrieved);
+    }
+
+    [Fact]
+    public void TryGetAnchor_Named_ThrowsOnNullKey()
+    {
+        using var scope = new CapabilityScope();
+        
+        Assert.Throws<ArgumentNullException>(() => scope.Anchors.TryGet(null!, out _));
+    }
+
+    [Fact]
+    public void TryGetAnchor_Named_ThrowsWhenDisposed()
+    {
+        var scope = new CapabilityScope();
+        scope.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => scope.Anchors.TryGet("key", out _));
+    }
+
+    [Fact]
+    public void GetAnchorOrThrow_Named_ThrowsWhenCollected()
+    {
+        using var scope = new CapabilityScope();
+        SetNamedAnchorAndCollect(scope, "temp-key");
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => scope.Anchors.GetOrThrow("temp-key"));
+        Assert.Contains("garbage collected", ex.Message);
+    }
+
+    [Fact]
+    public void TryGetAnchor_Named_ReturnsFalseWhenCollected()
+    {
+        using var scope = new CapabilityScope();
+        SetNamedAnchorAndCollect(scope, "temp-key2");
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var result = scope.Anchors.TryGet("temp-key2", out var retrieved);
+
+        Assert.False(result);
+        Assert.Null(retrieved);
+    }
+
+    private static void SetNamedAnchorAndCollect(CapabilityScope scope, string key)
+    {
+        scope.Anchors.Set(key, new TestAnchor { Value = 999 });
+    }
+
+    #endregion
+
+    #region Fluent Chaining Tests
+
+    [Fact]
+    public void FluentChaining_SetOwnerAndMultipleAnchors()
+    {
+        using var scope = new CapabilityScope();
+        var owner = new TestOwner { Name = "MainOwner" };
+        var anchor1 = new TestAnchor { Value = 42 };
+        var anchor2 = new AnotherAnchor { Flag = true };
+
+        scope.Owner.Set(owner)
+            .Scope
+            .Anchors
+             .Set(anchor1)
+             .Set(anchor2)
+             .Set("environment", new TestOwner { Name = "Env" });
+
+        Assert.Same(owner, scope.Owner.Get<TestOwner>());
+        Assert.Same(anchor1, scope.Anchors.GetOrThrow<TestAnchor>());
+        Assert.Same(anchor2, scope.Anchors.GetOrThrow<AnotherAnchor>());
+        Assert.NotNull(scope.Anchors.GetOrThrow("environment"));
+    }
+
+    #endregion
+}

--- a/src/Cocoar.Capabilities.Tests/PrimaryCapabilityTests.cs
+++ b/src/Cocoar.Capabilities.Tests/PrimaryCapabilityTests.cs
@@ -12,7 +12,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p0");
-        var comp = scope.For(subject).Add(new TestCapability("A")).Build();
+        var comp = scope.Compose(subject).Add(new TestCapability("A")).Build();
         Assert.False(comp.HasPrimary());
     }
 
@@ -21,7 +21,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p1");
-        var comp = scope.For(subject)
+        var comp = scope.Compose(subject)
                         .Add(new PrimaryTestCapability("P"))
                         .Add(new TestCapability("X"))
                         .Build();
@@ -34,7 +34,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p2");
-        var comp = scope.For(subject).Add(new TestCapability("A")).Build();
+        var comp = scope.Compose(subject).Add(new TestCapability("A")).Build();
         Assert.False(comp.TryGetPrimary(out var _));
     }
 
@@ -43,7 +43,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p3");
-        var comp = scope.For(subject)
+        var comp = scope.Compose(subject)
             .Add(new PrimaryTestCapability("P"))
             .Add(new TestCapability("A"))
             .Build();
@@ -56,7 +56,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p4");
-        var comp = scope.For(subject).Add(new PrimaryTestCapability("P")).Build();
+        var comp = scope.Compose(subject).Add(new PrimaryTestCapability("P")).Build();
         var primary = comp.GetPrimary();
         Assert.Equal("P", ((PrimaryTestCapability)primary).Name);
     }
@@ -66,7 +66,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p5");
-        var comp = scope.For(subject).Add(new TestCapability("X")).Build();
+        var comp = scope.Compose(subject).Add(new TestCapability("X")).Build();
         var ex = Assert.Throws<InvalidOperationException>(() => comp.GetPrimary());
         Assert.Contains("Primary capability not found", ex.Message);
     }
@@ -76,7 +76,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p6");
-        var comp = scope.For(subject)
+        var comp = scope.Compose(subject)
                         .Add(new PrimaryTestCapability("P"))
                         .Build();
         Assert.False(comp.TryGetPrimaryAs<AlternatePrimaryCapability>(out _));
@@ -87,7 +87,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p7");
-        var comp = scope.For(subject)
+        var comp = scope.Compose(subject)
                         .Add(new PrimaryTestCapability("P"))
                         .Build();
     Assert.True(comp.TryGetPrimaryAs<PrimaryTestCapability>(out var primary));
@@ -99,7 +99,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p8");
-        var comp = scope.For(subject).Add(new TestCapability("X")).Build();
+        var comp = scope.Compose(subject).Add(new TestCapability("X")).Build();
         Assert.Null(comp.GetPrimaryOrDefault());
     }
 
@@ -108,7 +108,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p9");
-        var comp = scope.For(subject).Add(new PrimaryTestCapability("P")).Build();
+        var comp = scope.Compose(subject).Add(new PrimaryTestCapability("P")).Build();
     var p = comp.GetPrimaryOrDefaultAs<PrimaryTestCapability>();
     Assert.NotNull(p);
     Assert.Equal("P", p!.Name);
@@ -119,7 +119,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p10");
-        var comp = scope.For(subject).Add(new PrimaryTestCapability("P")).Build();
+        var comp = scope.Compose(subject).Add(new PrimaryTestCapability("P")).Build();
     var p = comp.GetRequiredPrimaryAs<PrimaryTestCapability>();
     Assert.Equal("P", p.Name);
     }
@@ -129,7 +129,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p11");
-        var comp = scope.For(subject).Add(new TestCapability("Z")).Build();
+        var comp = scope.Compose(subject).Add(new TestCapability("Z")).Build();
         var ex = Assert.Throws<InvalidOperationException>(() => comp.GetRequiredPrimaryAs<PrimaryTestCapability>());
         Assert.Contains("Primary capability of type", ex.Message);
     }
@@ -139,7 +139,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p12");
-        var builder = scope.For(subject)
+        var builder = scope.Compose(subject)
                            .Add(new PrimaryTestCapability("First"))
                            .WithPrimary(new AlternatePrimaryCapability("Second"));
         var comp = builder.Build();
@@ -154,7 +154,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p13");
-        var comp = scope.For(subject)
+        var comp = scope.Compose(subject)
                         .Add(new PrimaryTestCapability("First"))
                         .WithPrimary(null)
                         .Build();
@@ -167,7 +167,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p14");
-        var builder = scope.For(subject)
+        var builder = scope.Compose(subject)
                            .Add(new PrimaryTestCapability("First"));
         var ex = Assert.Throws<InvalidOperationException>(() => builder.Add(new AlternatePrimaryCapability("Second")));
         Assert.Contains("primary capability is already set", ex.Message, StringComparison.OrdinalIgnoreCase);
@@ -178,7 +178,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p15");
-        var builder = scope.For(subject)
+        var builder = scope.Compose(subject)
                            .AddAs<IPrimaryCapability>(new PrimaryTestCapability("First"));
         var ex = Assert.Throws<InvalidOperationException>(() => builder.AddAs<IPrimaryCapability>(new AlternatePrimaryCapability("Second")));
         Assert.Contains("primary capability is already set", ex.Message, StringComparison.OrdinalIgnoreCase);
@@ -192,7 +192,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p16");
-        var builder = scope.For(subject)
+        var builder = scope.Compose(subject)
                            .Add(new PrimaryTestCapability("First"));
         var ex = Assert.Throws<InvalidOperationException>(() => builder.AddAs<(IPrimaryCapability, ITestContract)>(new TuplePrimaryCapability("Second")));
         Assert.Contains("primary capability is already set", ex.Message, StringComparison.OrdinalIgnoreCase);
@@ -203,7 +203,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p17");
-        var builder = scope.For(subject);
+        var builder = scope.Compose(subject);
         var ex = Assert.Throws<InvalidOperationException>(() => builder.AddAs<(IPrimaryCapability, IPrimaryCapability)>(new TuplePrimaryCapability("Both")));
         Assert.Contains("Multiple primary capability contracts", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -213,7 +213,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p18");
-        var builder = scope.For(subject)
+        var builder = scope.Compose(subject)
                            .Add(new PrimaryTestCapability("Original"));
 
         // Should silently ignore because a primary implementing PrimaryTestCapability already exists
@@ -229,7 +229,7 @@ public class PrimaryCapabilityTests
     {
         using var scope = NewScope();
         var subject = new StringSubject("p19");
-        var builder = scope.For(subject)
+        var builder = scope.Compose(subject)
                            .AddAs<IPrimaryCapability>(new PrimaryTestCapability("Original"));
 
         // Should no-op, not throw, not replace

--- a/src/Cocoar.Capabilities.Tests/RecomposeMultiTypeTests.cs
+++ b/src/Cocoar.Capabilities.Tests/RecomposeMultiTypeTests.cs
@@ -16,7 +16,7 @@ public class RecomposeMultiTypeTests
         var subject = new TestSubject(1);
         
         // Register capabilities under multiple types with explicit order
-        var composer = scope.For(subject);
+        var composer = scope.Compose(subject);
         composer.AddAs<(IMyInterface, LoggingCap)>(new LoggingCap(10), order: 10);
         composer.AddAs<(IMyInterface, DatabaseCap)>(new DatabaseCap(5), order: 5);
         composer.AddAs<(IMyInterface, LoggingCap)>(new LoggingCap(1), order: 1);

--- a/src/Cocoar.Capabilities.Tests/RecomposeTests.cs
+++ b/src/Cocoar.Capabilities.Tests/RecomposeTests.cs
@@ -9,7 +9,7 @@ public class RecomposeTests
     {
         using var scope = new CapabilityScope(new CapabilityScopeOptions { UseComposerRegistry = false, UseCompositionRegistry = false });
         var subject = new StringSubject("r1");
-        var baseComp = scope.For(subject).Add(new TestCapability("A")).Build(useRegistry: false);
+        var baseComp = scope.Compose(subject).Add(new TestCapability("A")).Build(useRegistry: false);
         Assert.Null(scope.Composers.GetOrDefault(subject));
         Assert.Null(scope.Compositions.GetOrDefault(subject));
 
@@ -27,7 +27,7 @@ public class RecomposeTests
     {
         using var scope = new CapabilityScope(new CapabilityScopeOptions { UseComposerRegistry = true, UseCompositionRegistry = false });
         var subject = new StringSubject("r2");
-    var baseComp = scope.For(subject).Add(new TestCapability("A")).Build(useRegistry: false); // composition explicitly disabled
+    var baseComp = scope.Compose(subject).Add(new TestCapability("A")).Build(useRegistry: false); // composition explicitly disabled
     // Composer registry true, composition disabled => composer removed, no composition stored
     Assert.Null(scope.Compositions.GetOrDefault(subject));
         Assert.Null(scope.Composers.GetOrDefault(subject));
@@ -46,7 +46,7 @@ public class RecomposeTests
     {
         using var scope = new CapabilityScope(new CapabilityScopeOptions { UseComposerRegistry = true, UseCompositionRegistry = true });
         var subject = new StringSubject("r3");
-        var baseComp = scope.For(subject).Add(new TestCapability("A")).Build();
+        var baseComp = scope.Compose(subject).Add(new TestCapability("A")).Build();
         var stored = scope.Compositions.GetOrDefault(subject);
         Assert.NotNull(stored);
         Assert.Same(baseComp, stored);

--- a/src/Cocoar.Capabilities.Tests/RegistryApiTests.cs
+++ b/src/Cocoar.Capabilities.Tests/RegistryApiTests.cs
@@ -34,7 +34,7 @@ public class RegistryApiTests
     {
         using var scope = new CapabilityScope();
         var subject = new Subject(4);
-        scope.For(subject).Add(new Cap("X")).Build(useRegistry: true);
+        scope.Compose(subject).Add(new Cap("X")).Build(useRegistry: true);
         Assert.True(scope.Compositions.Remove(subject));
         Assert.False(scope.Compositions.TryGet(subject, out _));
     }

--- a/src/Cocoar.Capabilities.Tests/SingleTestApproach.cs
+++ b/src/Cocoar.Capabilities.Tests/SingleTestApproach.cs
@@ -24,7 +24,7 @@ public sealed class SingleTestApproach : IDisposable
         var subject = new StringSubject("test");
 
         // Act: Build with explicit override to enable composition registry
-        var composition = _scope.For(subject)
+        var composition = _scope.Compose(subject)
             .Build(useRegistry: true);
 
         // Assert: Composition should be findable in registry

--- a/src/Cocoar.Capabilities.Tests/StringSubjectValueSemanticsTests.cs
+++ b/src/Cocoar.Capabilities.Tests/StringSubjectValueSemanticsTests.cs
@@ -13,7 +13,7 @@ public class StringSubjectValueSemanticsTests
         var s1 = new string("badword".ToCharArray()); // force new instance
         var s2 = new string("badword".ToCharArray()); // different instance, same contents
 
-        var comp = scope.For(s1, useRegistry: true)
+        var comp = scope.Compose(s1, useRegistry: true)
             .Add(new StringCapability("X"))
             .Build(useRegistry: true);
 
@@ -28,7 +28,7 @@ public class StringSubjectValueSemanticsTests
         var s1 = new string("topic".ToCharArray());
         var s2 = new string("topic".ToCharArray());
 
-        scope.For(s1, useRegistry: true)
+        scope.Compose(s1, useRegistry: true)
             .Add(new StringCapability("T"))
             .Build(useRegistry: true);
 

--- a/src/Cocoar.Capabilities.Tests/SubjectKeyCanonicalizerTests.cs
+++ b/src/Cocoar.Capabilities.Tests/SubjectKeyCanonicalizerTests.cs
@@ -18,7 +18,7 @@ public class SubjectKeyCanonicalizerTests
         using var scope = new CapabilityScope();
         var s1 = new string("alpha".ToCharArray());
         var s2 = new string("alpha".ToCharArray());
-        var comp1 = scope.For(s1).Add(new Cap("A")).Build(useRegistry: true);
+        var comp1 = scope.Compose(s1).Add(new Cap("A")).Build(useRegistry: true);
         var comp2 = scope.Compositions.GetRequired(s2);
         Assert.Same(comp1, comp2); // value semantics
     }
@@ -32,7 +32,7 @@ public class SubjectKeyCanonicalizerTests
         };
         using var scope = new CapabilityScope(opts);
         var lower = "mixedCase";
-        scope.For(lower).Build(useRegistry: true); // triggers sealing & canonicalization
+        scope.Compose(lower).Build(useRegistry: true); // triggers sealing & canonicalization
 
         // Reflection: fetch _sharedRegistry._canonicalizer and attempt TryRegisterOverride => false
         var scopeType = typeof(CapabilityScope);

--- a/src/Cocoar.Capabilities.Tests/TEST_CATALOG.md
+++ b/src/Cocoar.Capabilities.Tests/TEST_CATALOG.md
@@ -57,7 +57,7 @@ New Architecture Mapping
 ------------------------
 Old Static API | New Scoped API / Behavior
 -------------- | -------------------------
-Composer.For(subject).BuildAndRegister() | scope.For(subject).Add(...).Build(useRegistry: true)
+Composer.For(subject).BuildAndRegister() | scope.Compose(subject).Add(...).Build(useRegistry: true)
 Composition.FindOrDefault(subject)       | scope.Compositions.FindOrDefault(subject)
 Composition.FindRequired(subject)        | scope.Compositions.FindRequired(subject) (to implement if needed)
 Composition.TryFind(subject, out comp)   | scope.Compositions.TryFind(subject, out comp)

--- a/src/Cocoar.Capabilities.Tests/TestHelpers.cs
+++ b/src/Cocoar.Capabilities.Tests/TestHelpers.cs
@@ -33,11 +33,11 @@ public record TestPrimaryCapability(string Id, string Description) : IPrimaryCap
 public record OrderedCapability(int Order, string Name);
 public record HighPriorityCapability(string Name)
 {
-    public int Order => -100;
+    public static int Order => -100;
 }
 public record LowPriorityCapability(string Name)
 {
-    public int Order => 100;
+    public static int Order => 100;
 }
 
 public record OrderedTestCapability(string Name, int Order);

--- a/src/Cocoar.Capabilities.Tests/TupleTypeExtractorNegativeTests.cs
+++ b/src/Cocoar.Capabilities.Tests/TupleTypeExtractorNegativeTests.cs
@@ -10,7 +10,7 @@ public class TupleTypeExtractorNegativeTests
     public void TupleWithTwoPrimaryContracts_Throws()
     {
         using var scope = new CapabilityScope();
-        var composer = scope.For(new Subject(42));
+        var composer = scope.Compose(new Subject(42));
         // Register first primary normally
         composer.Add(new PrimaryA("P1"));
         // Adding tuple containing another primary should throw (duplicate primary detection)

--- a/src/Cocoar.Capabilities.Tests/ValueTypeRegistryTests.cs
+++ b/src/Cocoar.Capabilities.Tests/ValueTypeRegistryTests.cs
@@ -16,10 +16,10 @@ public class ValueTypeRegistryTests
     public void ValueType_Compositions_AreRetrievable()
     {
         using var scope = NewScope();
-        var c1 = scope.For(42, useRegistry: true)
+        var c1 = scope.Compose(42, useRegistry: true)
             .Add(new IntTestCapability("answer"))
             .Build(useRegistry: true);
-        var c2 = scope.For(7, useRegistry: true)
+        var c2 = scope.Compose(7, useRegistry: true)
             .Add(new IntTestCapability("seven"))
             .Build(useRegistry: true);
 
@@ -33,8 +33,8 @@ public class ValueTypeRegistryTests
     public void ValueType_Composition_Removal_Works()
     {
         using var scope = NewScope();
-        scope.For(100, useRegistry: true).Add(new IntTestCapability("hundred")).Build(useRegistry: true);
-        scope.For(200, useRegistry: true).Add(new IntTestCapability("two")) .Build(useRegistry: true);
+        scope.Compose(100, useRegistry: true).Add(new IntTestCapability("hundred")).Build(useRegistry: true);
+        scope.Compose(200, useRegistry: true).Add(new IntTestCapability("two")) .Build(useRegistry: true);
         Assert.True(scope.Compositions.Remove(100));
         Assert.False(scope.Compositions.TryGet(100, out _));
         Assert.True(scope.Compositions.TryGet(200, out _));
@@ -44,7 +44,7 @@ public class ValueTypeRegistryTests
     public void ValueType_NotRegistered_WhenUseRegistryFalse()
     {
         using var scope = NewScope();
-        var comp = scope.For(5, useRegistry: false)
+        var comp = scope.Compose(5, useRegistry: false)
             .Add(new IntTestCapability("five"))
             .Build(useRegistry: false);
         Assert.False(scope.Compositions.TryGet(5, out _));

--- a/src/Cocoar.Capabilities/CapabilityScope.cs
+++ b/src/Cocoar.Capabilities/CapabilityScope.cs
@@ -6,6 +6,8 @@ public sealed class CapabilityScope : IDisposable
     private readonly DefaultCapabilityRegistry _sharedRegistry;
     private readonly ComposerRegistryApi _composers;
     private readonly CompositionRegistryApi _compositions;
+    private readonly ScopeOwnerApi _owner;
+    private readonly ScopeAnchorsApi _anchors;
     private bool _disposed;
 
     public CapabilityScope(CapabilityScopeOptions? options = null)
@@ -14,21 +16,58 @@ public sealed class CapabilityScope : IDisposable
         _sharedRegistry = new DefaultCapabilityRegistry(new SubjectKeyCanonicalizer(_options.SubjectKeyMappers));
         _composers = new ComposerRegistryApi(_options, _sharedRegistry);
         _compositions = new CompositionRegistryApi(_options, _sharedRegistry);
+        _owner = new ScopeOwnerApi(this);
+        _anchors = new ScopeAnchorsApi(this);
     }
 
     public ComposerRegistryApi Composers => _composers;
     public CompositionRegistryApi Compositions => _compositions;
-    public Composer For(object subject, bool? useRegistry = null)
+    
+    /// <summary>
+    /// API for managing the owner of this scope.
+    /// </summary>
+    public ScopeOwnerApi Owner => _owner;
+    
+    /// <summary>
+    /// API for managing anchors of this scope.
+    /// </summary>
+    public ScopeAnchorsApi Anchors => _anchors;
+
+    /// <summary>
+    /// Creates a new <see cref="Composer"/> for the specified subject.
+    /// </summary>
+    /// <param name="subject">The subject to compose capabilities for.</param>
+    /// <param name="useRegistry">Optional. Whether to use the registry for this composition.</param>
+    /// <returns>A new <see cref="Composer"/> instance.</returns>
+    public Composer Compose(object subject, bool? useRegistry = null)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(subject);
         return new Composer(subject, _options, _sharedRegistry, useRegistry);
     }
+
+    /// <summary>
+    /// Creates a new <see cref="Composer"/> for the specified subject.
+    /// </summary>
+    /// <param name="subject">The subject to compose capabilities for.</param>
+    /// <param name="useRegistry">Optional. Whether to use the registry for this composition.</param>
+    /// <returns>A new <see cref="Composer"/> instance.</returns>
+    [Obsolete("Use Compose() instead. This method will be removed in a future version.")]
+    public Composer For(object subject, bool? useRegistry = null)
+    {
+        return Compose(subject, useRegistry);
+    }
+
     public Composer Recompose(IComposition composition, bool? useRegistry = null)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(composition);
         return new Composer(composition, _options, _sharedRegistry, useRegistry);
+    }
+
+    internal void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
     }
 
     public void Dispose()

--- a/src/Cocoar.Capabilities/Composition.cs
+++ b/src/Cocoar.Capabilities/Composition.cs
@@ -1,6 +1,6 @@
 namespace Cocoar.Capabilities;
 
-internal sealed class Composition : IComposition
+public sealed class Composition : IComposition
 {
     private IReadOnlyDictionary<Type, Array> _capabilitiesByType;
     private int _totalCapabilityCount;

--- a/src/Cocoar.Capabilities/ScopeAnchorsApi.cs
+++ b/src/Cocoar.Capabilities/ScopeAnchorsApi.cs
@@ -1,0 +1,215 @@
+namespace Cocoar.Capabilities;
+
+/// <summary>
+/// API for managing anchors of a <see cref="CapabilityScope"/>.
+/// </summary>
+public sealed class ScopeAnchorsApi
+{
+    public CapabilityScope Scope { get; }
+    private readonly Dictionary<Type, WeakReference<object>> _typedAnchors = new();
+    private readonly Dictionary<string, WeakReference<object>> _namedAnchors = new();
+
+    internal ScopeAnchorsApi(CapabilityScope scope)
+    {
+        Scope = scope;
+    }
+
+    /// <summary>
+    /// Sets a typed anchor for this scope. Only one anchor per type is supported.
+    /// The anchor is stored as a weak reference.
+    /// </summary>
+    /// <typeparam name="T">The type of the anchor.</typeparam>
+    /// <param name="anchor">The anchor object.</param>
+    /// <returns>The <see cref="CapabilityScope"/> for chaining.</returns>
+    public ScopeAnchorsApi Set<T>(T anchor) where T : class
+    {
+        Scope.ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(anchor);
+        _typedAnchors[typeof(T)] = new WeakReference<object>(anchor);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a named anchor for this scope.
+    /// The anchor is stored as a weak reference.
+    /// </summary>
+    /// <param name="key">The key for the anchor.</param>
+    /// <param name="anchor">The anchor object.</param>
+    /// <returns>The <see cref="CapabilityScope"/> for chaining.</returns>
+    public ScopeAnchorsApi Set(string key, object anchor)
+    {
+        Scope.ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(anchor);
+        _namedAnchors[key] = new WeakReference<object>(anchor);
+        return this;
+    }
+
+    /// <summary>
+    /// Gets a typed anchor from this scope.
+    /// Throws if the anchor is not set or has been garbage collected.
+    /// </summary>
+    /// <typeparam name="T">The type of the anchor.</typeparam>
+    /// <returns>The anchor.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no anchor of the specified type is set or it has been collected.</exception>
+    public T Get<T>() where T : class
+    {
+        Scope.ThrowIfDisposed();
+        
+        if (!_typedAnchors.TryGetValue(typeof(T), out var weakRef))
+        {
+            throw new InvalidOperationException($"No anchor of type {typeof(T).Name} has been set for this scope.");
+        }
+
+        if (!weakRef.TryGetTarget(out var target))
+        {
+            throw new InvalidOperationException($"The anchor of type {typeof(T).Name} has been garbage collected.");
+        }
+
+        return (T)target;
+    }
+
+    /// <summary>
+    /// Gets a named anchor from this scope.
+    /// Throws if the anchor is not set or has been garbage collected.
+    /// </summary>
+    /// <param name="key">The key of the anchor.</param>
+    /// <returns>The anchor.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no anchor with the specified key is set or it has been collected.</exception>
+    public object Get(string key)
+    {
+        Scope.ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(key);
+
+        if (!_namedAnchors.TryGetValue(key, out var weakRef))
+        {
+            throw new InvalidOperationException($"No anchor with key '{key}' has been set for this scope.");
+        }
+
+        if (!weakRef.TryGetTarget(out var target))
+        {
+            throw new InvalidOperationException($"The anchor with key '{key}' has been garbage collected.");
+        }
+
+        return target;
+    }
+
+    /// <summary>
+    /// Gets a typed anchor from this scope.
+    /// Alias for <see cref="Get{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the anchor.</typeparam>
+    /// <returns>The anchor.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no anchor of the specified type is set or it has been collected.</exception>
+    public T GetOrThrow<T>() where T : class => Get<T>();
+
+    /// <summary>
+    /// Gets a named anchor from this scope.
+    /// Alias for <see cref="Get(string)"/>.
+    /// </summary>
+    /// <param name="key">The key of the anchor.</param>
+    /// <returns>The anchor.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no anchor with the specified key is set or it has been collected.</exception>
+    public object GetOrThrow(string key) => Get(key);
+
+    /// <summary>
+    /// Tries to get a typed anchor from this scope.
+    /// </summary>
+    /// <typeparam name="T">The type of the anchor.</typeparam>
+    /// <param name="anchor">The anchor, if found.</param>
+    /// <returns>True if the anchor was found; otherwise false.</returns>
+    public bool TryGet<T>(out T? anchor) where T : class
+    {
+        Scope.ThrowIfDisposed();
+        
+        if (_typedAnchors.TryGetValue(typeof(T), out var weakRef) && weakRef.TryGetTarget(out var target))
+        {
+            anchor = (T)target;
+            return true;
+        }
+
+        anchor = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Tries to get a named anchor from this scope.
+    /// </summary>
+    /// <param name="key">The key of the anchor.</param>
+    /// <param name="anchor">The anchor, if found.</param>
+    /// <returns>True if the anchor was found; otherwise false.</returns>
+    public bool TryGet(string key, out object? anchor)
+    {
+        Scope.ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(key);
+        
+        if (_namedAnchors.TryGetValue(key, out var weakRef) && weakRef.TryGetTarget(out var target))
+        {
+            anchor = target;
+            return true;
+        }
+
+        anchor = null;
+        return false;
+    }    /// <summary>
+    /// Creates a <see cref="Composer"/> for a typed anchor.
+    /// </summary>
+    /// <typeparam name="T">The type of the anchor.</typeparam>
+    /// <param name="useRegistry">Optional. Whether to use the registry for this composition.</param>
+    /// <returns>A <see cref="Composer"/> for the anchor.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no anchor of the specified type is set or it has been collected.</exception>
+    public Composer Compose<T>(bool? useRegistry = null) where T : class
+    {
+        var anchor = Get<T>();
+        return Scope.Compose(anchor, useRegistry);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="Composer"/> for a named anchor.
+    /// </summary>
+    /// <param name="key">The key of the anchor.</param>
+    /// <param name="useRegistry">Optional. Whether to use the registry for this composition.</param>
+    /// <returns>A <see cref="Composer"/> for the anchor.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no anchor with the specified key is set or it has been collected.</exception>
+    public Composer Compose(string key, bool? useRegistry = null)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        var anchor = Get(key);
+        return Scope.Compose(anchor, useRegistry);
+    }
+
+    /// <summary>
+    /// Gets the composition for a typed anchor.
+    /// </summary>
+    /// <typeparam name="T">The type of the anchor.</typeparam>
+    /// <returns>The composition for the anchor, or null if not found.</returns>
+    public Composition? GetComposition<T>() where T : class
+    {
+        if (!TryGet<T>(out var anchor) || anchor is null)
+        {
+            return null;
+        }
+
+        return Scope.Compositions.GetOrDefault(anchor) as Composition;
+    }
+
+    /// <summary>
+    /// Gets the composition for a named anchor.
+    /// </summary>
+    /// <param name="key">The key of the anchor.</param>
+    /// <returns>The composition for the anchor, or null if not found.</returns>
+    public Composition? GetComposition(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        if (!TryGet(key, out var anchor) || anchor is null)
+        {
+            return null;
+        }
+
+        return Scope.Compositions.GetOrDefault(anchor) as Composition;
+    }
+
+    internal Dictionary<Type, WeakReference<object>> InternalTypedAnchors => _typedAnchors;
+    internal Dictionary<string, WeakReference<object>> InternalNamedAnchors => _namedAnchors;
+}

--- a/src/Cocoar.Capabilities/ScopeOwnerApi.cs
+++ b/src/Cocoar.Capabilities/ScopeOwnerApi.cs
@@ -1,0 +1,162 @@
+namespace Cocoar.Capabilities;
+
+/// <summary>
+/// API for managing the owner of a <see cref="CapabilityScope"/>.
+/// </summary>
+public sealed class ScopeOwnerApi
+{
+    public CapabilityScope Scope { get; }
+    private WeakReference<object>? _owner;
+
+    internal ScopeOwnerApi(CapabilityScope scope)
+    {
+        Scope = scope;
+    }
+
+    
+    /// <summary>
+    /// Sets the owner of the scope. The owner is stored as a weak reference.
+    /// Throws if an owner has already been set.
+    /// </summary>
+    /// <param name="owner">The object to set as the owner.</param>
+    /// <returns>The <see cref="ScopeOwnerApi"/> for chaining.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if an owner has already been set.</exception>
+    public ScopeOwnerApi Set(object owner)
+    {
+        Scope.ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(owner);
+        
+        if (_owner is not null && _owner.TryGetTarget(out _))
+        {
+            throw new InvalidOperationException("An owner has already been set for this scope. Use Replace() to replace an existing owner.");
+        }
+        
+        _owner = new WeakReference<object>(owner);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the owner of the scope, or sets it if no owner exists.
+    /// The owner is stored as a weak reference.
+    /// </summary>
+    /// <param name="owner">The object to set as the owner.</param>
+    /// <returns>The <see cref="ScopeOwnerApi"/> for chaining.</returns>
+    public ScopeOwnerApi Replace(object owner)
+    {
+        Scope.ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(owner);
+        _owner = new WeakReference<object>(owner);
+        return this;
+    }
+
+    /// <summary>
+    /// Gets the owner of the scope, cast to the specified type.
+    /// Throws if the owner is not set, has been garbage collected, or is not of the expected type.
+    /// </summary>
+    /// <typeparam name="T">The expected type of the owner.</typeparam>
+    /// <returns>The owner.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no owner is set or it has been collected.</exception>
+    /// <exception cref="InvalidCastException">Thrown when the owner is not of type <typeparamref name="T"/>.</exception>
+    public T Get<T>() where T : class
+    {
+        Scope.ThrowIfDisposed();
+        
+        if (_owner is null)
+        {
+            throw new InvalidOperationException("No owner has been set for this scope.");
+        }
+
+        if (!_owner.TryGetTarget(out var target))
+        {
+            throw new InvalidOperationException("The owner has been garbage collected.");
+        }
+
+        if (target is not T typedOwner)
+        {
+            throw new InvalidCastException($"Owner is of type {target.GetType().Name}, not {typeof(T).Name}");
+        }
+
+        return typedOwner;
+    }
+
+    /// <summary>
+    /// Gets the owner of the scope, cast to the specified type.
+    /// Alias for <see cref="Get{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The expected type of the owner.</typeparam>
+    /// <returns>The owner.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no owner is set or it has been collected.</exception>
+    /// <exception cref="InvalidCastException">Thrown when the owner is not of type <typeparamref name="T"/>.</exception>
+    public T GetOrThrow<T>() where T : class => Get<T>();
+
+    /// <summary>
+    /// Tries to get the owner of the scope, cast to the specified type.
+    /// </summary>
+    /// <typeparam name="T">The expected type of the owner.</typeparam>
+    /// <param name="owner">The owner, if found and of the correct type.</param>
+    /// <returns>True if the owner was found and is of type <typeparamref name="T"/>; otherwise false.</returns>
+    public bool TryGet<T>(out T? owner) where T : class
+    {
+        Scope.ThrowIfDisposed();
+        
+        if (_owner is not null && _owner.TryGetTarget(out var target) && target is T typedOwner)
+        {
+            owner = typedOwner;
+            return true;
+        }
+
+        owner = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="Composer"/> for the owner of this scope.
+    /// </summary>
+    /// <param name="useRegistry">Optional. Whether to use the registry for this composition.</param>
+    /// <returns>A <see cref="Composer"/> for the owner.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no owner is set or it has been collected.</exception>
+    public Composer Compose(bool? useRegistry = null)
+    {
+        if (!TryGet<object>(out var owner) || owner is null)
+        {
+            throw new InvalidOperationException("No owner has been set for this scope or it has been garbage collected.");
+        }
+
+        return Scope.Compose(owner, useRegistry);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="Composer"/> for the owner of this scope, cast to the specified type.
+    /// </summary>
+    /// <typeparam name="T">The expected type of the owner.</typeparam>
+    /// <param name="useRegistry">Optional. Whether to use the registry for this composition.</param>
+    /// <returns>A <see cref="Composer"/> for the owner.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no owner is set or it has been collected.</exception>
+    /// <exception cref="InvalidCastException">Thrown when the owner is not of type <typeparamref name="T"/>.</exception>
+    public Composer Compose<T>(bool? useRegistry = null) where T : class
+    {
+        var owner = Get<T>();
+        return Scope.Compose(owner, useRegistry);
+    }
+
+    /// <summary>
+    /// Gets the composition for the owner of this scope.
+    /// </summary>
+    /// <typeparam name="T">The expected type of the owner.</typeparam>
+    /// <returns>The composition for the owner, or null if not found.</returns>
+    public Composition? GetComposition<T>() where T : class
+    {
+        if (!TryGet<T>(out var owner) || owner is null)
+        {
+            return null;
+        }
+
+        return Scope.Compositions.GetOrDefault(owner) as Composition;
+    }
+
+    internal WeakReference<object>? InternalOwnerReference
+    {
+        get => _owner;
+        set => _owner = value;
+    }
+}

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,9 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <!-- Clear all inherited sources first -->
+    <clear />
     <!-- Official NuGet source -->
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <!-- GitHub package source for Cocoar packages -->
+    <add key="github_cocoar" value="https://nuget.pkg.github.com/cocoar-dev/index.json" />
   </packageSources>
+  
+  <packageSourceMapping>
+    <!-- Cocoar packages from GitHub -->
+    <packageSource key="github_cocoar">
+      <package pattern="Cocoar.*" />
+    </packageSource>
+    
+    <!-- All other packages from nuget.org -->
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
   
   <config>
     <!-- Restore settings -->


### PR DESCRIPTION
Introduces scope.Owner.* and scope.Anchors.* APIs to associate scopes with context objects, enabling composition against meaningful subjects when only the scope is available.

- Owner API: Set, Replace, Get, GetOrThrow, TryGet, Compose, GetComposition
- Anchors API: Typed and named variants of the same methods
- Weak reference storage prevents memory leaks
- Fluent chaining via .Scope property
- 218 tests passing (all new + existing)
- Comprehensive documentation in ADR, README, and API reference