### PR TITLE
Add Using* extension methods for fluent capability usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
   - Direct composition via `Owner.Compose()` and `Anchors.Compose<T>()`
   - Methods: `Set`, `Replace`, `Get`, `GetOrThrow`, `TryGet`, `Compose`, `GetComposition`
   - Comprehensive documentation in ADR, README, API reference, and quick reference guide
+- **Using* Extension Methods**: Fluent convenience methods for inline capability usage
+  - `UsingFirst<T>()`, `UsingFirstOrDefault<T>()` - Use first capability with action or function
+  - `UsingLast<T>()`, `UsingLastOrDefault<T>()` - Use last capability with action or function
+  - `UsingEach<T>()` - Execute action or function for each capability
+  - `UsingAll<T>()` - Execute action or function with full collection
+  - All methods maintain semantic consistency with existing `Get*` methods
+  - Action-based overloads return `IComposition` for chaining
+  - Function-based overloads return results directly
 
 ## [1.0.0] - 2025-10-10
 

--- a/adr/2025-10-25-using-extensions.md
+++ b/adr/2025-10-25-using-extensions.md
@@ -1,0 +1,326 @@
+# ADR-002: Introduce `Using*` Extension Methods for Fluent Capability Usage
+
+**Status**: Accepted  
+**Date**: 2025-10-25  
+**Decision type**: API Enhancement  
+**Scope**: Cocoar.Capabilities (framework-wide)
+
+---
+
+## Context
+
+The `IComposition` interface provides explicit retrieval methods for capabilities:
+
+- `GetRequiredFirst<T>()` / `GetFirstOrDefault<T>()` / `TryGetFirst<T>(out T?)`
+- `GetRequiredLast<T>()` / `GetLastOrDefault<T>()` / `TryGetLast<T>(out T?)`
+- `GetAll<T>()`
+
+While functionally complete, common usage patterns like "retrieve and immediately use" require verbose code:
+
+```csharp
+var logger = composition.GetRequiredFirst<ILogger>();
+logger.Info("started");
+
+var handlers = composition.GetAll<IEventHandler>();
+foreach (var handler in handlers)
+    handler.Handle(evt);
+```
+
+For inline usage where the capability instance isn't needed afterward, this feels heavyweight. We want to provide **ergonomic convenience methods** that:
+
+1. Support fluent, chainable usage for common patterns
+2. Maintain 100% semantic consistency with existing `Get*` methods
+3. Cover both single-instance and multi-instance scenarios
+4. Preserve explicit intent (first/last/each/all)
+
+---
+
+## Decision
+
+Introduce a comprehensive set of **`Using*` extension methods** on `IComposition` that mirror the existing `Get*` API surface, optimized for inline/fluent usage.
+
+These methods are **pure convenience wrappers** with **zero behavioral changes**—they directly delegate to existing retrieval methods and execute user-provided delegates.
+
+---
+
+## API Surface
+
+```csharp
+namespace Cocoar.Capabilities;
+
+public static class CompositionUsingExtensions
+{
+    // ============= FIRST =============
+    
+    /// <summary>
+    /// Uses the first capability of type <typeparamref name="T"/>.
+    /// Throws if no instances exist. Returns composition for chaining.
+    /// </summary>
+    public static IComposition UsingFirst<T>(this IComposition composition, Action<T> use)
+        where T : class;
+
+    /// <summary>
+    /// Uses the first capability of type <typeparamref name="T"/> and returns a result.
+    /// Throws if no instances exist.
+    /// </summary>
+    public static TResult UsingFirst<T, TResult>(this IComposition composition, Func<T, TResult> use)
+        where T : class;
+
+    /// <summary>
+    /// Uses the first capability of type <typeparamref name="T"/> if it exists.
+    /// Silently skips if no instances exist. Returns composition for chaining.
+    /// </summary>
+    public static IComposition UsingFirstOrDefault<T>(this IComposition composition, Action<T> use)
+        where T : class;
+
+    // ============= LAST =============
+    
+    /// <summary>
+    /// Uses the last capability of type <typeparamref name="T"/>.
+    /// Throws if no instances exist. Returns composition for chaining.
+    /// </summary>
+    public static IComposition UsingLast<T>(this IComposition composition, Action<T> use)
+        where T : class;
+
+    /// <summary>
+    /// Uses the last capability of type <typeparamref name="T"/> and returns a result.
+    /// Throws if no instances exist.
+    /// </summary>
+    public static TResult UsingLast<T, TResult>(this IComposition composition, Func<T, TResult> use)
+        where T : class;
+
+    /// <summary>
+    /// Uses the last capability of type <typeparamref name="T"/> if it exists.
+    /// Silently skips if no instances exist. Returns composition for chaining.
+    /// </summary>
+    public static IComposition UsingLastOrDefault<T>(this IComposition composition, Action<T> use)
+        where T : class;
+
+    // ============= EACH =============
+    
+    /// <summary>
+    /// Executes <paramref name="use"/> for each capability of type <typeparamref name="T"/>.
+    /// Silent if no instances exist (iterates empty collection). Returns composition for chaining.
+    /// </summary>
+    public static IComposition UsingEach<T>(this IComposition composition, Action<T> use)
+        where T : class;
+
+    /// <summary>
+    /// Executes <paramref name="use"/> for each capability of type <typeparamref name="T"/> and collects results.
+    /// Returns a list of results (empty if no instances exist).
+    /// </summary>
+    public static IReadOnlyList<TResult> UsingEach<T, TResult>(this IComposition composition, Func<T, TResult> use)
+        where T : class;
+
+    // ============= ALL =============
+    
+    /// <summary>
+    /// Executes <paramref name="use"/> with the full collection of <typeparamref name="T"/> capabilities.
+    /// Use for aggregations or collection-level operations. Returns composition for chaining.
+    /// </summary>
+    public static IComposition UsingAll<T>(this IComposition composition, Action<IReadOnlyList<T>> use)
+        where T : class;
+
+    /// <summary>
+    /// Executes <paramref name="use"/> with the full collection of <typeparamref name="T"/> capabilities and returns a result.
+    /// Use for aggregations or collection-level operations.
+    /// </summary>
+    public static TResult UsingAll<T, TResult>(this IComposition composition, Func<IReadOnlyList<T>, TResult> use)
+        where T : class;
+}
+```
+
+---
+
+## Usage Examples
+
+### Single Instance Usage
+
+```csharp
+// Required first (throws if missing)
+composition.UsingFirst<ILogger>(log => log.Info("started"));
+
+// Required first with result
+var count = composition.UsingFirst<IRepository, int>(repo => repo.Count());
+
+// Optional first (silent if missing, chainable)
+composition
+    .UsingFirstOrDefault<ILogger>(log => log.Info("started"))
+    .UsingFirst<IMetrics>(m => m.Inc());
+
+// Last instance (when order matters)
+composition.UsingLast<IMiddleware>(m => m.Execute());
+```
+
+### Multiple Instance Usage
+
+```csharp
+// Process each capability individually
+composition.UsingEach<IEventHandler>(handler => handler.Handle(evt));
+
+// Map each to a result
+var counts = composition.UsingEach<IRepository, int>(repo => repo.Count());
+// Returns: [5, 12, 8]
+
+// Aggregate operation on collection
+var total = composition.UsingAll<IRepository, int>(repos => repos.Sum(r => r.Count()));
+// Returns: 25
+
+// Collection operation (chainable)
+composition.UsingAll<IPlugin>(plugins => 
+{
+    foreach (var p in plugins)
+        p.Initialize();
+});
+```
+
+### Fluent Chaining
+
+```csharp
+composition
+    .UsingFirst<ILogger>(log => log.Info("starting"))
+    .UsingEach<IPlugin>(p => p.Initialize())
+    .UsingFirstOrDefault<IOptionalFeature>(f => f.Configure())
+    .UsingAll<IEventHandler>(handlers => handlers.ForEach(h => h.Register()))
+    .UsingLast<IMetrics>(m => m.Inc("startup"));
+```
+
+---
+
+## Semantics & Guarantees
+
+### Delegation to Existing Methods
+
+All `Using*` methods **directly delegate** to existing `IComposition` methods:
+
+| `Using*` Method | Delegates To |
+|----------------|--------------|
+| `UsingFirst<T>()` | `GetRequiredFirst<T>()` |
+| `UsingFirstOrDefault<T>()` | `GetFirstOrDefault<T>()` |
+| `UsingLast<T>()` | `GetRequiredLast<T>()` |
+| `UsingLastOrDefault<T>()` | `GetLastOrDefault<T>()` |
+| `UsingEach<T>()` | `GetAll<T>()` |
+| `UsingAll<T>()` | `GetAll<T>()` |
+
+### Exception Behavior
+
+- **`UsingFirst<T>()` / `UsingLast<T>()`**: Throw if no instances exist (same as `GetRequired*`)
+- **`UsingFirstOrDefault<T>()` / `UsingLastOrDefault<T>()`**: Silent if missing
+- **`UsingEach<T>()` / `UsingAll<T>()`**: Silent if collection is empty
+
+### Chainability
+
+- All `Action<T>`-based overloads return `IComposition` for fluent chaining
+- All `Func<T, TResult>`-based overloads return `TResult` (terminate the chain)
+
+### Thread Safety & Lifetime
+
+- **No additional isolation or scoping**: `Using*` methods provide **zero** lifetime management or thread safety beyond what the underlying composition provides
+- They are **pure convenience wrappers** for inline execution
+
+---
+
+## Consequences
+
+### Positive
+
+✅ **Improved ergonomics** for common inline usage patterns  
+✅ **Fluent, chainable API** for sequential capability usage  
+✅ **100% consistency** with existing `Get*` semantics  
+✅ **Zero behavioral changes** — pure convenience layer  
+✅ **Self-documenting intent** via explicit method names (`First`, `Last`, `Each`, `All`)  
+✅ **Complete coverage** of single/multi-instance scenarios  
+
+### Neutral
+
+⚠️ **Expanded API surface** — 10 new methods, but all follow a consistent, predictable pattern  
+⚠️ **No "simple" `Using<T>()`** — users must choose `First`, `Last`, `Each`, or `All` (this is intentional to avoid ambiguity)  
+
+### Negative
+
+None identified. The extension methods are opt-in and don't affect existing code.
+
+---
+
+## Alternatives Considered
+
+### 1. Generic `Using<T>()` without position specifiers
+
+**Rejected**: Ambiguous when multiple instances exist. Which one gets used? Forces users to guess or read implementation.
+
+### 2. Different naming: `ActAs<T>()`, `As<T>()`, `Use<T>()`
+
+**Rejected**: 
+- `ActAs` implies the composition "becomes" the capability (wrong mental model)
+- `As` is too generic and doesn't convey position (first/last)
+- `Use` without position is ambiguous
+
+`Using*` with explicit position (`First`, `Last`, `Each`, `All`) is clearer and mirrors the existing API.
+
+### 3. Only add `UsingFirst` and `UsingEach` (minimal set)
+
+**Rejected**: Incomplete. Users need `Last` for ordered scenarios, `Try*` for optional capabilities, and `*OrDefault` for silent fallback in chains.
+
+### 4. Return `bool` from `TryUsing*` methods
+
+**Rejected**: Breaks chainability. Returning `IComposition` allows fluent chaining while still being silent on missing capabilities. Users who need explicit success/failure checks can use `TryGet*` directly.
+
+---
+
+## Backward Compatibility & Migration
+
+- **100% backward compatible**: New extension methods, no changes to existing API
+- **Opt-in**: Teams can adopt incrementally or not at all
+- **No performance impact**: Direct delegation with zero overhead
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- Verify each `Using*` method delegates correctly to its `Get*` counterpart
+- Verify exception behavior (throwing vs. silent)
+- Verify return types (chainable vs. result)
+- Verify `*OrDefault` silent behavior
+- Verify `UsingEach` iteration over all instances
+- Verify `UsingAll` receives full collection
+
+### Integration Tests
+
+- Fluent chaining scenarios (multiple `Using*` calls in sequence)
+- Mixed required/optional capability usage
+- Empty collection handling (`UsingEach`, `UsingAll`)
+- Exception propagation from user delegates
+
+---
+
+## Documentation Notes
+
+- Position `Using*` as **convenience methods for inline usage**
+- Recommend using `Get*` when you need to store/reuse the capability instance
+- Recommend using `Using*` when you immediately invoke and don't need the instance afterward
+- Document chainability patterns and when to break chains (when you need a result)
+- Add examples showing `First` vs. `Each` vs. `All` distinctions
+
+---
+
+## Future Work (non-breaking extensions)
+
+- **Diagnostics**: Enhanced exceptions that show available capabilities, positions, or composition context
+- **Analyzers**: Suggest `Using*` over `Get*` + immediate invocation patterns
+- **Additional overloads**: If new retrieval patterns are added to `IComposition`, mirror them with corresponding `Using*` methods
+
+---
+
+## Decision Rationale
+
+The `Using*` extensions solve a real ergonomic pain point (verbose retrieve-and-use patterns) without introducing semantic complexity or behavioral changes. By mirroring the existing `Get*` API structure, they feel like a natural extension of the framework rather than a separate concept.
+
+The explicit position/collection specifiers (`First`, `Last`, `Each`, `All`) prevent ambiguity and make call sites self-documenting, aligning with the framework's design philosophy of clarity over brevity.
+
+---
+
+## Summary
+
+Introduce 10 `Using*` extension methods that provide fluent, chainable, inline capability usage while maintaining perfect semantic consistency with the existing `IComposition` API. These are pure convenience wrappers with zero behavioral changes.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,6 +10,7 @@ Complete API reference for the Cocoar.Capabilities library.
 - [ScopeAnchorsApi](#scopeanchorsapi)
 - [Composer](#composer)
 - [IComposition](#icomposition)
+- [Using Extensions](#using-extensions)
 - [IPrimaryCapability](#iprimarycapability)
 - [ComposerRegistryApi](#composerregistryapi)
 - [CompositionRegistryApi](#compositionregistryapi)
@@ -341,6 +342,145 @@ if (composition.TryGetPrimary(out var primary))
 // Type-safe primary access
 var userPrimary = composition.GetRequiredPrimaryAs<UserPrimaryCapability>();
 ```
+
+---
+
+## Using Extensions
+
+Fluent extension methods for inline capability usage. These are convenience wrappers over the `Get*` methods that enable chainable, expressive usage patterns.
+
+**Extension methods on `IComposition`**
+
+### Single Instance Methods (First)
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `UsingFirst<T>(Action<T> use)` | `IComposition` | Uses the first T capability; throws if none exist. Chainable. |
+| `UsingFirst<T, TResult>(Func<T, TResult> use)` | `TResult` | Uses the first T capability and returns a result; throws if none exist |
+| `UsingFirstOrDefault<T>(Action<T> use)` | `IComposition` | Uses the first T capability if it exists; silent if missing. Chainable. |
+
+### Single Instance Methods (Last)
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `UsingLast<T>(Action<T> use)` | `IComposition` | Uses the last T capability; throws if none exist. Chainable. |
+| `UsingLast<T, TResult>(Func<T, TResult> use)` | `TResult` | Uses the last T capability and returns a result; throws if none exist |
+| `UsingLastOrDefault<T>(Action<T> use)` | `IComposition` | Uses the last T capability if it exists; silent if missing. Chainable. |
+
+### Multiple Instance Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `UsingEach<T>(Action<T> use)` | `IComposition` | Executes action for each T capability; silent if none exist. Chainable. |
+| `UsingEach<T, TResult>(Func<T, TResult> use)` | `IReadOnlyList<TResult>` | Executes function for each T capability and collects results |
+| `UsingAll<T>(Action<IReadOnlyList<T>> use)` | `IComposition` | Executes action with full collection of T capabilities. Chainable. |
+| `UsingAll<T, TResult>(Func<IReadOnlyList<T>, TResult> use)` | `TResult` | Executes function with full collection and returns a result |
+
+### Delegation Mapping
+
+All `Using*` methods delegate directly to existing `IComposition` methods:
+
+| `Using*` Method | Delegates To |
+|----------------|--------------|
+| `UsingFirst<T>()` | `GetRequiredFirst<T>()` |
+| `UsingFirstOrDefault<T>()` | `GetFirstOrDefault<T>()` |
+| `UsingLast<T>()` | `GetRequiredLast<T>()` |
+| `UsingLastOrDefault<T>()` | `GetLastOrDefault<T>()` |
+| `UsingEach<T>()` / `UsingAll<T>()` | `GetAll<T>()` |
+
+### Examples
+
+**Single instance usage:**
+
+```csharp
+// Required first (throws if missing)
+composition.UsingFirst<ILogger>(log => log.Info("started"));
+
+// Required first with result
+var count = composition.UsingFirst<IRepository, int>(repo => repo.Count());
+
+// Optional (silent if missing)
+composition.UsingFirstOrDefault<ILogger>(log => log.Info("started"));
+
+// Last instance (when order matters)
+composition.UsingLast<IMiddleware>(m => m.Execute());
+```
+
+**Multiple instance usage:**
+
+```csharp
+// Process each capability individually
+composition.UsingEach<IEventHandler>(handler => handler.Handle(evt));
+
+// Map each to a result
+var counts = composition.UsingEach<IRepository, int>(repo => repo.Count());
+// Returns: [5, 12, 8]
+
+// Aggregate operation on collection
+var total = composition.UsingAll<IRepository, int>(
+    repos => repos.Sum(r => r.Count())
+);
+// Returns: 25
+
+// Collection operation (chainable)
+composition.UsingAll<IPlugin>(plugins => 
+{
+    foreach (var p in plugins)
+        p.Initialize();
+});
+```
+
+**Fluent chaining:**
+
+```csharp
+composition
+    .UsingFirst<ILogger>(log => log.Info("starting"))
+    .UsingEach<IPlugin>(p => p.Initialize())
+    .UsingFirstOrDefault<IOptionalFeature>(f => f.Configure())
+    .UsingAll<IEventHandler>(handlers => 
+    {
+        foreach (var h in handlers)
+            h.Register();
+    })
+    .UsingLast<IMetrics>(m => m.Inc("startup"));
+```
+
+**When to use `Using*` vs `Get*`:**
+
+```csharp
+// Use Get* when you need to store/reuse the instance
+var logger = composition.GetRequiredFirst<ILogger>();
+logger.Info("step 1");
+logger.Info("step 2");
+
+// Use Using* for inline/one-off usage
+composition.UsingFirst<ILogger>(log => log.Info("one-off message"));
+
+// Use Using* for fluent chaining
+composition
+    .UsingFirst<ILogger>(log => log.Info("starting"))
+    .UsingEach<IValidator>(v => v.Validate());
+```
+
+### Exception Behavior
+
+| Method | Behavior |
+|--------|----------|
+| `UsingFirst<T>()` / `UsingLast<T>()` | Throws if no instances exist |
+| `UsingFirstOrDefault<T>()` / `UsingLastOrDefault<T>()` | Silent if missing (no-op) |
+| `UsingEach<T>()` / `UsingAll<T>()` | Silent if collection is empty |
+
+### Thread Safety
+
+- ✅ All `Using*` methods are thread-safe (they operate on immutable `IComposition` instances)
+- ✅ User-provided delegates may execute concurrently if the composition is shared across threads
+- ⚠️ User code inside delegates is responsible for its own thread safety
+
+### Performance
+
+- **Zero allocation overhead** beyond the user delegate itself
+- Direct delegation to existing `Get*` methods (no intermediate objects)
+- Chainable methods return the same `IComposition` instance (no copying)
 
 ---
 

--- a/src/Cocoar.Capabilities.Tests/CompositionUsingExtensionsTests.cs
+++ b/src/Cocoar.Capabilities.Tests/CompositionUsingExtensionsTests.cs
@@ -1,0 +1,443 @@
+namespace Cocoar.Capabilities.Tests;
+
+public class CompositionUsingExtensionsTests
+{
+    private interface ITestCapability
+    {
+        void Execute();
+        int GetValue();
+    }
+
+    private class TestCapability : ITestCapability
+    {
+        public int Value { get; }
+        public bool WasExecuted { get; private set; }
+
+        public TestCapability(int value)
+        {
+            Value = value;
+        }
+
+        public void Execute()
+        {
+            WasExecuted = true;
+        }
+
+        public int GetValue() => Value;
+    }
+
+    [Fact]
+    public void UsingFirst_WithAction_ExecutesActionAndReturnsComposition()
+    {
+        using var scope = new CapabilityScope();
+        var capability = new TestCapability(42);
+        var composition = scope.Compose(new object())
+            .AddAs<ITestCapability>(capability)
+            .Build();
+
+        var result = composition.UsingFirst<ITestCapability>(cap => cap.Execute());
+
+        Assert.Same(composition, result);
+        Assert.True(capability.WasExecuted);
+    }
+
+    [Fact]
+    public void UsingFirst_WithFunc_ReturnsResult()
+    {
+        using var scope = new CapabilityScope();
+        var capability = new TestCapability(42);
+        var composition = scope.Compose(new object())
+            .AddAs<ITestCapability>(capability)
+            .Build();
+
+        var result = composition.UsingFirst<ITestCapability, int>(cap => cap.GetValue());
+
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void UsingFirst_WhenCapabilityMissing_Throws()
+    {
+        using var scope = new CapabilityScope();
+        var composition = scope.Compose(new object()).Build();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            composition.UsingFirst<ITestCapability>(cap => cap.Execute()));
+    }
+
+    [Fact]
+    public void UsingFirst_IsChainable()
+    {
+        using var scope = new CapabilityScope();
+        var cap1 = new TestCapability(1);
+        var cap2 = new TestCapability(2);
+        var composition = scope.Compose(new object())
+            .AddAs<ITestCapability>(cap1)
+            .AddAs<ITestCapability>(cap2)
+            .Build();
+
+        var result = composition
+            .UsingFirst<ITestCapability>(cap => cap.Execute())
+            .UsingLast<ITestCapability>(cap => cap.Execute());
+
+        Assert.Same(composition, result);
+        Assert.True(cap1.WasExecuted);
+        Assert.True(cap2.WasExecuted);
+    }
+
+    [Fact]
+    public void UsingFirstOrDefault_WhenCapabilityExists_ExecutesAction()
+    {
+        using var scope = new CapabilityScope();
+        var capability = new TestCapability(42);
+        var composition = scope.Compose(new object())
+            .AddAs<ITestCapability>(capability)
+            .Build();
+
+        var result = composition.UsingFirstOrDefault<ITestCapability>(cap => cap.Execute());
+
+        Assert.Same(composition, result);
+        Assert.True(capability.WasExecuted);
+    }
+
+    [Fact]
+    public void UsingFirstOrDefault_WhenCapabilityMissing_DoesNotThrow()
+    {
+        using var scope = new CapabilityScope();
+        var composition = scope.Compose(new object()).Build();
+        var executed = false;
+
+        var result = composition.UsingFirstOrDefault<ITestCapability>(cap => executed = true);
+
+        Assert.Same(composition, result);
+        Assert.False(executed);
+    }
+
+    [Fact]
+    public void UsingLast_WithAction_ExecutesActionAndReturnsComposition()
+    {
+        using var scope = new CapabilityScope();
+        var capability = new TestCapability(42);
+        var composition = scope.Compose(new object())
+            .AddAs<ITestCapability>(capability)
+            .Build();
+
+        var result = composition.UsingLast<ITestCapability>(cap => cap.Execute());
+
+        Assert.Same(composition, result);
+        Assert.True(capability.WasExecuted);
+    }
+
+    [Fact]
+    public void UsingLast_WithFunc_ReturnsResult()
+    {
+        using var scope = new CapabilityScope();
+        var cap1 = new TestCapability(1);
+        var cap2 = new TestCapability(2);
+        var composition = scope.Compose(new object())
+            .AddAs<ITestCapability>(cap1, order: 1)
+            .AddAs<ITestCapability>(cap2, order: 2)
+            .Build();
+
+        var result = composition.UsingLast<ITestCapability, int>(cap => cap.GetValue());
+
+        Assert.Equal(2, result);
+    }
+
+    [Fact]
+    public void UsingLast_WhenCapabilityMissing_Throws()
+    {
+        using var scope = new CapabilityScope();
+        var composition = scope.Compose(new object()).Build();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            composition.UsingLast<ITestCapability>(cap => cap.Execute()));
+    }
+
+    [Fact]
+    public void UsingLastOrDefault_WhenCapabilityExists_ExecutesAction()
+    {
+        using var scope = new CapabilityScope();
+        var capability = new TestCapability(42);
+        var composition = scope.Compose(new object())
+            .AddAs<ITestCapability>(capability)
+            .Build();
+
+        var result = composition.UsingLastOrDefault<ITestCapability>(cap => cap.Execute());
+
+        Assert.Same(composition, result);
+        Assert.True(capability.WasExecuted);
+    }
+
+    [Fact]
+    public void UsingLastOrDefault_WhenCapabilityMissing_DoesNotThrow()
+    {
+        using var scope = new CapabilityScope();
+        var composition = scope.Compose(new object()).Build();
+        var executed = false;
+
+        var result = composition.UsingLastOrDefault<ITestCapability>(cap => executed = true);
+
+        Assert.Same(composition, result);
+        Assert.False(executed);
+    }
+
+    [Fact]
+    public void UsingEach_WithAction_ExecutesForEachCapability()
+    {
+        using var scope = new CapabilityScope();
+        var cap1 = new TestCapability(1);
+        var cap2 = new TestCapability(2);
+        var cap3 = new TestCapability(3);
+        var composition = scope.Compose(new object())
+            .AddAs<ITestCapability>(cap1)
+            .AddAs<ITestCapability>(cap2)
+            .AddAs<ITestCapability>(cap3)
+            .Build();
+
+        var result = composition.UsingEach<ITestCapability>(cap => cap.Execute());
+
+        Assert.Same(composition, result);
+        Assert.True(cap1.WasExecuted);
+        Assert.True(cap2.WasExecuted);
+        Assert.True(cap3.WasExecuted);
+    }
+
+    [Fact]
+    public void UsingEach_WithFunc_CollectsResults()
+    {
+        using var scope = new CapabilityScope();
+        var cap1 = new TestCapability(1);
+        var cap2 = new TestCapability(2);
+        var cap3 = new TestCapability(3);
+        var composition = scope.Compose(new object())
+            .AddAs<ITestCapability>(cap1, order: 1)
+            .AddAs<ITestCapability>(cap2, order: 2)
+            .AddAs<ITestCapability>(cap3, order: 3)
+            .Build();
+
+        var results = composition.UsingEach<ITestCapability, int>(cap => cap.GetValue());
+
+        Assert.Equal(3, results.Count);
+        Assert.Equal(1, results[0]);
+        Assert.Equal(2, results[1]);
+        Assert.Equal(3, results[2]);
+    }
+
+    [Fact]
+    public void UsingEach_WithAction_WhenEmpty_DoesNotThrow()
+    {
+        using var scope = new CapabilityScope();
+        var composition = scope.Compose(new object()).Build();
+        var executed = false;
+
+        var result = composition.UsingEach<ITestCapability>(cap => executed = true);
+
+        Assert.Same(composition, result);
+        Assert.False(executed);
+    }
+
+    [Fact]
+    public void UsingEach_WithFunc_WhenEmpty_ReturnsEmptyList()
+    {
+        using var scope = new CapabilityScope();
+        var composition = scope.Compose(new object()).Build();
+
+        var results = composition.UsingEach<ITestCapability, int>(cap => cap.GetValue());
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void UsingEach_IsChainable()
+    {
+        using var scope = new CapabilityScope();
+        var cap1 = new TestCapability(1);
+        var cap2 = new TestCapability(2);
+        var composition = scope.Compose(new object())
+            .AddAs<ITestCapability>(cap1)
+            .AddAs<ITestCapability>(cap2)
+            .Build();
+
+        var result = composition
+            .UsingEach<ITestCapability>(cap => cap.Execute())
+            .UsingFirst<ITestCapability>(cap => { });
+
+        Assert.Same(composition, result);
+        Assert.True(cap1.WasExecuted);
+        Assert.True(cap2.WasExecuted);
+    }
+
+    [Fact]
+    public void UsingAll_WithAction_ReceivesFullCollection()
+    {
+        using var scope = new CapabilityScope();
+        var cap1 = new TestCapability(1);
+        var cap2 = new TestCapability(2);
+        var cap3 = new TestCapability(3);
+        var composition = scope.Compose(new object())
+            .AddAs<ITestCapability>(cap1)
+            .AddAs<ITestCapability>(cap2)
+            .AddAs<ITestCapability>(cap3)
+            .Build();
+
+        IReadOnlyList<ITestCapability>? receivedCollection = null;
+
+        var result = composition.UsingAll<ITestCapability>(caps =>
+        {
+            receivedCollection = caps;
+        });
+
+        Assert.Same(composition, result);
+        Assert.NotNull(receivedCollection);
+        Assert.Equal(3, receivedCollection.Count);
+    }
+
+    [Fact]
+    public void UsingAll_WithFunc_ReturnsAggregatedResult()
+    {
+        using var scope = new CapabilityScope();
+        var cap1 = new TestCapability(1);
+        var cap2 = new TestCapability(2);
+        var cap3 = new TestCapability(3);
+        var composition = scope.Compose(new object())
+            .AddAs<ITestCapability>(cap1)
+            .AddAs<ITestCapability>(cap2)
+            .AddAs<ITestCapability>(cap3)
+            .Build();
+
+        var sum = composition.UsingAll<ITestCapability, int>(caps =>
+            caps.Sum(c => c.GetValue()));
+
+        Assert.Equal(6, sum);
+    }
+
+    [Fact]
+    public void UsingAll_WithAction_WhenEmpty_ExecutesWithEmptyCollection()
+    {
+        using var scope = new CapabilityScope();
+        var composition = scope.Compose(new object()).Build();
+        IReadOnlyList<ITestCapability>? receivedCollection = null;
+
+        var result = composition.UsingAll<ITestCapability>(caps =>
+        {
+            receivedCollection = caps;
+        });
+
+        Assert.Same(composition, result);
+        Assert.NotNull(receivedCollection);
+        Assert.Empty(receivedCollection);
+    }
+
+    [Fact]
+    public void UsingAll_WithFunc_WhenEmpty_ExecutesWithEmptyCollection()
+    {
+        using var scope = new CapabilityScope();
+        var composition = scope.Compose(new object()).Build();
+
+        var count = composition.UsingAll<ITestCapability, int>(caps => caps.Count);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void UsingFirst_NullComposition_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ((IComposition)null!).UsingFirst<ITestCapability>(cap => { }));
+    }
+
+    [Fact]
+    public void UsingFirst_NullAction_Throws()
+    {
+        using var scope = new CapabilityScope();
+        var composition = scope.Compose(new object()).Build();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            composition.UsingFirst<ITestCapability>(null!));
+    }
+
+    [Fact]
+    public void UsingEach_NullComposition_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ((IComposition)null!).UsingEach<ITestCapability>(cap => { }));
+    }
+
+    [Fact]
+    public void UsingEach_NullAction_Throws()
+    {
+        using var scope = new CapabilityScope();
+        var composition = scope.Compose(new object()).Build();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            composition.UsingEach<ITestCapability>((Action<ITestCapability>)null!));
+    }
+
+    [Fact]
+    public void UsingAll_NullComposition_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ((IComposition)null!).UsingAll<ITestCapability>(caps => { }));
+    }
+
+    [Fact]
+    public void UsingAll_NullAction_Throws()
+    {
+        using var scope = new CapabilityScope();
+        var composition = scope.Compose(new object()).Build();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            composition.UsingAll<ITestCapability>((Action<IReadOnlyList<ITestCapability>>)null!));
+    }
+
+    [Fact]
+    public void ComplexChain_MixedUsingMethods_WorksCorrectly()
+    {
+        using var scope = new CapabilityScope();
+        var cap1 = new TestCapability(1);
+        var cap2 = new TestCapability(2);
+        var cap3 = new TestCapability(3);
+        var composition = scope.Compose(new object())
+            .AddAs<ITestCapability>(cap1, order: 1)
+            .AddAs<ITestCapability>(cap2, order: 2)
+            .AddAs<ITestCapability>(cap3, order: 3)
+            .Build();
+
+        var executionLog = new List<string>();
+
+        var result = composition
+            .UsingFirst<ITestCapability>(cap => executionLog.Add($"First: {cap.GetValue()}"))
+            .UsingEach<ITestCapability>(cap => executionLog.Add($"Each: {cap.GetValue()}"))
+            .UsingLast<ITestCapability>(cap => executionLog.Add($"Last: {cap.GetValue()}"))
+            .UsingAll<ITestCapability>(caps => executionLog.Add($"All count: {caps.Count}"));
+
+        Assert.Same(composition, result);
+        Assert.Equal(6, executionLog.Count);
+        Assert.Equal("First: 1", executionLog[0]);
+        Assert.Equal("Each: 1", executionLog[1]);
+        Assert.Equal("Each: 2", executionLog[2]);
+        Assert.Equal("Each: 3", executionLog[3]);
+        Assert.Equal("Last: 3", executionLog[4]);
+        Assert.Equal("All count: 3", executionLog[5]);
+    }
+
+    [Fact]
+    public void ChainWithOrDefault_WhenMissing_ContinuesChain()
+    {
+        using var scope = new CapabilityScope();
+        var cap = new TestCapability(42);
+        var composition = scope.Compose(new object())
+            .AddAs<ITestCapability>(cap)
+            .Build();
+
+        var executed = false;
+
+        var result = composition
+            .UsingFirstOrDefault<object>(obj => { })
+            .UsingFirst<ITestCapability>(c => executed = true);
+
+        Assert.Same(composition, result);
+        Assert.True(executed);
+    }
+}

--- a/src/Cocoar.Capabilities/CompositionUsingExtensions.cs
+++ b/src/Cocoar.Capabilities/CompositionUsingExtensions.cs
@@ -1,0 +1,217 @@
+namespace Cocoar.Capabilities;
+
+/// <summary>
+/// Fluent extension methods for inline capability usage on <see cref="IComposition"/>.
+/// These are convenience wrappers over the Get* methods that enable chainable, expressive usage patterns.
+/// </summary>
+public static class CompositionUsingExtensions
+{
+    // ============= FIRST =============
+    
+    /// <summary>
+    /// Uses the first capability of type <typeparamref name="T"/>.
+    /// Throws if no instances exist. Returns composition for chaining.
+    /// </summary>
+    /// <typeparam name="T">The capability type to use.</typeparam>
+    /// <param name="composition">The composition to retrieve the capability from.</param>
+    /// <param name="use">The action to execute with the capability.</param>
+    /// <returns>The same composition instance for fluent chaining.</returns>
+    /// <exception cref="InvalidOperationException">If no capability of type <typeparamref name="T"/> exists.</exception>
+    public static IComposition UsingFirst<T>(this IComposition composition, Action<T> use)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(composition);
+        ArgumentNullException.ThrowIfNull(use);
+        
+        use(composition.GetRequiredFirst<T>());
+        return composition;
+    }
+
+    /// <summary>
+    /// Uses the first capability of type <typeparamref name="T"/> and returns a result.
+    /// Throws if no instances exist.
+    /// </summary>
+    /// <typeparam name="T">The capability type to use.</typeparam>
+    /// <typeparam name="TResult">The type of result to return.</typeparam>
+    /// <param name="composition">The composition to retrieve the capability from.</param>
+    /// <param name="use">The function to execute with the capability.</param>
+    /// <returns>The result of the function.</returns>
+    /// <exception cref="InvalidOperationException">If no capability of type <typeparamref name="T"/> exists.</exception>
+    public static TResult UsingFirst<T, TResult>(this IComposition composition, Func<T, TResult> use)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(composition);
+        ArgumentNullException.ThrowIfNull(use);
+        
+        return use(composition.GetRequiredFirst<T>());
+    }
+
+    /// <summary>
+    /// Uses the first capability of type <typeparamref name="T"/> if it exists.
+    /// Silently skips if no instances exist. Returns composition for chaining.
+    /// </summary>
+    /// <typeparam name="T">The capability type to use.</typeparam>
+    /// <param name="composition">The composition to retrieve the capability from.</param>
+    /// <param name="use">The action to execute with the capability.</param>
+    /// <returns>The same composition instance for fluent chaining.</returns>
+    public static IComposition UsingFirstOrDefault<T>(this IComposition composition, Action<T> use)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(composition);
+        ArgumentNullException.ThrowIfNull(use);
+        
+        var cap = composition.GetFirstOrDefault<T>();
+        if (cap != null)
+        {
+            use(cap);
+        }
+        return composition;
+    }
+
+    // ============= LAST =============
+    
+    /// <summary>
+    /// Uses the last capability of type <typeparamref name="T"/>.
+    /// Throws if no instances exist. Returns composition for chaining.
+    /// </summary>
+    /// <typeparam name="T">The capability type to use.</typeparam>
+    /// <param name="composition">The composition to retrieve the capability from.</param>
+    /// <param name="use">The action to execute with the capability.</param>
+    /// <returns>The same composition instance for fluent chaining.</returns>
+    /// <exception cref="InvalidOperationException">If no capability of type <typeparamref name="T"/> exists.</exception>
+    public static IComposition UsingLast<T>(this IComposition composition, Action<T> use)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(composition);
+        ArgumentNullException.ThrowIfNull(use);
+        
+        use(composition.GetRequiredLast<T>());
+        return composition;
+    }
+
+    /// <summary>
+    /// Uses the last capability of type <typeparamref name="T"/> and returns a result.
+    /// Throws if no instances exist.
+    /// </summary>
+    /// <typeparam name="T">The capability type to use.</typeparam>
+    /// <typeparam name="TResult">The type of result to return.</typeparam>
+    /// <param name="composition">The composition to retrieve the capability from.</param>
+    /// <param name="use">The function to execute with the capability.</param>
+    /// <returns>The result of the function.</returns>
+    /// <exception cref="InvalidOperationException">If no capability of type <typeparamref name="T"/> exists.</exception>
+    public static TResult UsingLast<T, TResult>(this IComposition composition, Func<T, TResult> use)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(composition);
+        ArgumentNullException.ThrowIfNull(use);
+        
+        return use(composition.GetRequiredLast<T>());
+    }
+
+    /// <summary>
+    /// Uses the last capability of type <typeparamref name="T"/> if it exists.
+    /// Silently skips if no instances exist. Returns composition for chaining.
+    /// </summary>
+    /// <typeparam name="T">The capability type to use.</typeparam>
+    /// <param name="composition">The composition to retrieve the capability from.</param>
+    /// <param name="use">The action to execute with the capability.</param>
+    /// <returns>The same composition instance for fluent chaining.</returns>
+    public static IComposition UsingLastOrDefault<T>(this IComposition composition, Action<T> use)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(composition);
+        ArgumentNullException.ThrowIfNull(use);
+        
+        var cap = composition.GetLastOrDefault<T>();
+        if (cap != null)
+        {
+            use(cap);
+        }
+        return composition;
+    }
+
+    // ============= EACH =============
+    
+    /// <summary>
+    /// Executes <paramref name="use"/> for each capability of type <typeparamref name="T"/>.
+    /// Silent if no instances exist (iterates empty collection). Returns composition for chaining.
+    /// </summary>
+    /// <typeparam name="T">The capability type to use.</typeparam>
+    /// <param name="composition">The composition to retrieve capabilities from.</param>
+    /// <param name="use">The action to execute for each capability.</param>
+    /// <returns>The same composition instance for fluent chaining.</returns>
+    public static IComposition UsingEach<T>(this IComposition composition, Action<T> use)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(composition);
+        ArgumentNullException.ThrowIfNull(use);
+        
+        foreach (var cap in composition.GetAll<T>())
+        {
+            use(cap);
+        }
+        return composition;
+    }
+
+    /// <summary>
+    /// Executes <paramref name="use"/> for each capability of type <typeparamref name="T"/> and collects results.
+    /// Returns a list of results (empty if no instances exist).
+    /// </summary>
+    /// <typeparam name="T">The capability type to use.</typeparam>
+    /// <typeparam name="TResult">The type of result to collect.</typeparam>
+    /// <param name="composition">The composition to retrieve capabilities from.</param>
+    /// <param name="use">The function to execute for each capability.</param>
+    /// <returns>A read-only list of results from executing the function on each capability.</returns>
+    public static IReadOnlyList<TResult> UsingEach<T, TResult>(this IComposition composition, Func<T, TResult> use)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(composition);
+        ArgumentNullException.ThrowIfNull(use);
+        
+        var all = composition.GetAll<T>();
+        var results = new List<TResult>(all.Count);
+        foreach (var cap in all)
+        {
+            results.Add(use(cap));
+        }
+        return results;
+    }
+
+    // ============= ALL =============
+    
+    /// <summary>
+    /// Executes <paramref name="use"/> with the full collection of <typeparamref name="T"/> capabilities.
+    /// Use for aggregations or collection-level operations. Returns composition for chaining.
+    /// </summary>
+    /// <typeparam name="T">The capability type to use.</typeparam>
+    /// <param name="composition">The composition to retrieve capabilities from.</param>
+    /// <param name="use">The action to execute with the full collection of capabilities.</param>
+    /// <returns>The same composition instance for fluent chaining.</returns>
+    public static IComposition UsingAll<T>(this IComposition composition, Action<IReadOnlyList<T>> use)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(composition);
+        ArgumentNullException.ThrowIfNull(use);
+        
+        use(composition.GetAll<T>());
+        return composition;
+    }
+
+    /// <summary>
+    /// Executes <paramref name="use"/> with the full collection of <typeparamref name="T"/> capabilities and returns a result.
+    /// Use for aggregations or collection-level operations.
+    /// </summary>
+    /// <typeparam name="T">The capability type to use.</typeparam>
+    /// <typeparam name="TResult">The type of result to return.</typeparam>
+    /// <param name="composition">The composition to retrieve capabilities from.</param>
+    /// <param name="use">The function to execute with the full collection of capabilities.</param>
+    /// <returns>The result of the function.</returns>
+    public static TResult UsingAll<T, TResult>(this IComposition composition, Func<IReadOnlyList<T>, TResult> use)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(composition);
+        ArgumentNullException.ThrowIfNull(use);
+        
+        return use(composition.GetAll<T>());
+    }
+}


### PR DESCRIPTION
## Add Using* Extension Methods for Fluent Capability Usage

### Summary
Introduces 10 new fluent extension methods on `IComposition` for inline capability usage patterns, complementing the existing `Get*` retrieval methods.

### Motivation
Common patterns like "retrieve and immediately use" required verbose code. These convenience methods enable cleaner, more expressive inline usage while maintaining 100% semantic consistency with existing APIs.

### API Surface
**First/Last (6 methods):**
- `UsingFirst<T>(Action<T>)` / `UsingFirst<T, TResult>(Func<T, TResult>)`
- `UsingFirstOrDefault<T>(Action<T>)`
- `UsingLast<T>(Action<T>)` / `UsingLast<T, TResult>(Func<T, TResult>)`
- `UsingLastOrDefault<T>(Action<T>)`

**Each/All (4 methods):**
- `UsingEach<T>(Action<T>)` / `UsingEach<T, TResult>(Func<T, TResult>)`
- `UsingAll<T>(Action<IReadOnlyList<T>>)` / `UsingAll<T, TResult>(Func<IReadOnlyList<T>, TResult>)`

### Key Features
- Action-based overloads return `IComposition` for fluent chaining
- Function-based overloads return results directly
- Zero behavioral changes - pure delegation to existing `Get*` methods
- Maintains explicit intent with First/Last/Each/All position specifiers
- OrDefault variants for silent/optional behavior

### Examples
```csharp
// Before
var logger = composition.GetRequiredFirst<ILogger>();
logger.Info("started");

// After
composition.UsingFirst<ILogger>(log => log.Info("started"));

// Chaining
composition
    .UsingFirst<ILogger>(log => log.Info("started"))
    .UsingEach<IEventHandler>(handler => handler.Handle(evt))
    .UsingLast<IMiddleware>(m => m.Execute());